### PR TITLE
[ECO-486][ECO-538] Add balance update support

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "diesel",
+ "hex",
  "serde",
  "serde_json",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -497,7 +497,6 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "diesel",
- "hex",
  "serde",
  "serde_json",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -157,7 +157,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -385,7 +385,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -497,6 +497,8 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "diesel",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -528,7 +530,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -548,7 +550,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.25",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -594,7 +596,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -754,7 +756,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1543,7 +1545,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1655,7 +1657,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2177,29 +2179,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.102"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -2404,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.25"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2450,7 +2452,7 @@ checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2554,7 +2556,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2769,7 +2771,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3019,7 +3021,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
  "wasm-bindgen-shared",
 ]
 
@@ -3053,7 +3055,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3254,5 +3256,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.32",
 ]

--- a/rust/processor/src/processors/econia_processor.rs
+++ b/rust/processor/src/processors/econia_processor.rs
@@ -16,7 +16,7 @@ use chrono::{DateTime, Utc};
 use diesel::{result::Error, PgConnection};
 use econia_db::{
     models::{
-        CancelOrderEvent, ChangeOrderSizeEvent, FillEvent, MarketAccountHandle, MarketAccounts,
+        CancelOrderEvent, ChangeOrderSizeEvent, FillEvent, MarketAccountHandle,
         MarketRegistrationEvent, PlaceLimitOrderEvent, PlaceMarketOrderEvent, PlaceSwapOrderEvent,
     },
     schema::{
@@ -643,12 +643,12 @@ impl ProcessorTrait for EconiaTransactionProcessor {
                         if resource.r#type.as_ref().expect("No resource type")
                             == &market_accounts_type
                         {
-                            let market_accounts: MarketAccounts =
+                            let resource_data: serde_json::Value =
                                 serde_json::from_str(&resource.data)
                                     .expect("Failed to parse MarketAccounts");
                             market_account_handles.push(MarketAccountHandle {
                                 user: resource.address.clone(),
-                                handle: market_accounts.map.handle,
+                                handle: resource_data["map"]["handle"].to_string(),
                             })
                         }
                     },

--- a/rust/processor/src/processors/econia_processor.rs
+++ b/rust/processor/src/processors/econia_processor.rs
@@ -670,7 +670,8 @@ impl ProcessorTrait for EconiaTransactionProcessor {
                                 .expect("Failed to parse MarketAccounts");
                             market_account_handles.push(MarketAccountHandle {
                                 user: resource.address.clone(),
-                                handle: data["map"]["handle"].as_str().unwrap().to_string(),
+                                handle: opt_value_to_string(data["map"]["handle"])?,
+                                creation_time: time,
                             })
                         }
                     },
@@ -681,10 +682,9 @@ impl ProcessorTrait for EconiaTransactionProcessor {
                         {
                             continue;
                         }
-                        let table_key: serde_json::Value = serde_json::from_str(&table_data.key)
-                            .expect("Failed to parse market account ID");
                         let market_account_id =
-                            u128::from_str(table_key.as_str().unwrap()).unwrap();
+                            u128::from_str(opt_value_to_string(&table_data.key)?)
+                                .expect("Failed to parse market account ID");
                         let data: serde_json::Value = serde_json::from_str(&table_data.value)
                             .expect("Failed to parse MarketAccount");
                         balance_updates.push(BalanceUpdate {
@@ -693,26 +693,12 @@ impl ProcessorTrait for EconiaTransactionProcessor {
                             market_id: ((market_account_id >> SHIFT_MARKET_ID) as u64).into(),
                             custodian_id: ((market_account_id & HI_64) as u64).into(),
                             time,
-                            base_total: u64::from_str(data["base_total"].as_str().unwrap())
-                                .unwrap()
-                                .into(),
-                            base_available: u64::from_str(data["base_available"].as_str().unwrap())
-                                .unwrap()
-                                .into(),
-                            base_ceiling: u64::from_str(data["base_ceiling"].as_str().unwrap())
-                                .unwrap()
-                                .into(),
-                            quote_total: u64::from_str(data["quote_total"].as_str().unwrap())
-                                .unwrap()
-                                .into(),
-                            quote_available: u64::from_str(
-                                data["quote_available"].as_str().unwrap(),
-                            )
-                            .unwrap()
-                            .into(),
-                            quote_ceiling: u64::from_str(data["quote_ceiling"].as_str().unwrap())
-                                .unwrap()
-                                .into(),
+                            base_total: opt_value_to_big_decimal(data["base_total"])?,
+                            base_available: opt_value_to_big_decimal(data["base_available"])?,
+                            base_ceiling: opt_value_to_big_decimal(data["base_ceiling"])?,
+                            quote_total: opt_value_to_big_decimal(data["quote_total"])?,
+                            quote_available: opt_value_to_big_decimal(data["quote_available"])?,
+                            quote_ceiling: opt_value_to_big_decimal(data["quote_ceiling"])?,
                         })
                     },
                     _ => continue,

--- a/rust/processor/src/processors/econia_processor.rs
+++ b/rust/processor/src/processors/econia_processor.rs
@@ -686,12 +686,26 @@ impl ProcessorTrait for EconiaTransactionProcessor {
                             market_id: ((market_account_id >> SHIFT_MARKET_ID) as u64).into(),
                             custodian_id: ((market_account_id & HI_64) as u64).into(),
                             time,
-                            base_total: data["base_total"].as_u64().unwrap().into(),
-                            base_available: data["base_available"].as_u64().unwrap().into(),
-                            base_ceiling: data["base_ceiling"].as_u64().unwrap().into(),
-                            quote_total: data["quote_total"].as_u64().unwrap().into(),
-                            quote_available: data["quote_available"].as_u64().unwrap().into(),
-                            quote_ceiling: data["quote_ceiling"].as_u64().unwrap().into(),
+                            base_total: u64::from_str(data["base_total"].as_str().unwrap())
+                                .unwrap()
+                                .into(),
+                            base_available: u64::from_str(data["base_available"].as_str().unwrap())
+                                .unwrap()
+                                .into(),
+                            base_ceiling: u64::from_str(data["base_ceiling"].as_str().unwrap())
+                                .unwrap()
+                                .into(),
+                            quote_total: u64::from_str(data["quote_total"].as_str().unwrap())
+                                .unwrap()
+                                .into(),
+                            quote_available: u64::from_str(
+                                data["quote_available"].as_str().unwrap(),
+                            )
+                            .unwrap()
+                            .into(),
+                            quote_ceiling: u64::from_str(data["quote_ceiling"].as_str().unwrap())
+                                .unwrap()
+                                .into(),
                         })
                     },
                     _ => continue,

--- a/rust/processor/src/processors/econia_processor.rs
+++ b/rust/processor/src/processors/econia_processor.rs
@@ -648,7 +648,10 @@ impl ProcessorTrait for EconiaTransactionProcessor {
                                     .expect("Failed to parse MarketAccounts");
                             market_account_handles.push(MarketAccountHandle {
                                 user: resource.address.clone(),
-                                handle: resource_data["map"]["handle"].to_string(),
+                                handle: resource_data["map"]["handle"]
+                                    .as_str()
+                                    .unwrap()
+                                    .to_string(),
                             })
                         }
                     },

--- a/rust/processor/src/processors/econia_processor.rs
+++ b/rust/processor/src/processors/econia_processor.rs
@@ -648,7 +648,7 @@ impl ProcessorTrait for EconiaTransactionProcessor {
                                     .expect("Failed to parse MarketAccounts");
                             market_account_handles.push(MarketAccountHandle {
                                 user: resource.address.clone(),
-                                handle: market_accounts.map.handle.to_hex_literal(),
+                                handle: market_accounts.map.handle,
                             })
                         }
                     },

--- a/rust/processor/src/processors/econia_processor.rs
+++ b/rust/processor/src/processors/econia_processor.rs
@@ -648,7 +648,7 @@ impl ProcessorTrait for EconiaTransactionProcessor {
                                     .expect("Failed to parse MarketAccounts");
                             market_account_handles.push(MarketAccountHandle {
                                 user: resource.address.clone(),
-                                handle: market_accounts.map.handle,
+                                handle: market_accounts.map.handle.to_hex_literal(),
                             })
                         }
                     },

--- a/rust/processor/src/processors/econia_processor.rs
+++ b/rust/processor/src/processors/econia_processor.rs
@@ -681,8 +681,14 @@ impl ProcessorTrait for EconiaTransactionProcessor {
                         {
                             continue;
                         }
-                        let market_account_id = u128::from_str(&table_data.key)
-                            .expect("Failed to parse market account ID");
+                        let table_key: serde_json::Value = serde_json::from_str(&table_data.key)
+                            .expect("Failed to parse market account ID to JSON");
+                        let market_account_id = u128::from_str(
+                            &table_key
+                                .as_str()
+                                .expect("Failed to parse market account ID to string"),
+                        )
+                        .expect("Failed to parse market account ID to u128");
                         let data: serde_json::Value = serde_json::from_str(&table_data.value)
                             .expect("Failed to parse MarketAccount");
                         balance_updates.push(BalanceUpdate {


### PR DESCRIPTION
https://github.com/econia-labs/econia/pull/511

* Delete deprecated Rust README
* Add processor for `MarketAccounts` table handles
* Add missing postgres views to old migrations
* Add processor for `MarketAccount` table entries
* Add view function to join on table handle for balance updates

## To verify

```yaml
health_check_port: 8085
server_config:
  processor_config:
    type: econia_transaction_processor
    econia_address: 0xc0de11113b427d35ece1d8991865a941c0578b0f349acabbe9753863c24109ff
  postgres_connection_string: postgres://econia:econia@postgres:5432/econia
  indexer_grpc_data_service_address: https://grpc.testnet.aptoslabs.com:443
  indexer_grpc_http2_ping_interval_in_secs: 60
  indexer_grpc_http2_ping_timeout_in_secs: 10
  auth_token: <my_auth_token>
  starting_version: 683453241
```

Run Docker compose instructions per the docs site then see http://0.0.0.0:3001/balance_updates