### PR TITLE
Fix testnet error

### DIFF
--- a/rust/processor/src/processors/econia_processor.rs
+++ b/rust/processor/src/processors/econia_processor.rs
@@ -770,7 +770,11 @@ impl ProcessorTrait for EconiaTransactionProcessor {
                 } else {
                     continue;
                 };
-                let address = strip_hex_number(address.to_string())?;
+                let address = if let Ok(addr) = strip_hex_number(address.to_string()) {
+                    addr
+                } else {
+                    continue;
+                };
                 let event_type = format!("{address}::{tail}");
                 let txn_version = BigDecimal::from(txn.version);
                 let event_idx = BigDecimal::from(index as u64);


### PR DESCRIPTION
Presently, the Econia processor assumes that event types are of the form `address::module::struct`, however, the event emissions APIs also support native types, including vectors. Hence, `vector<address::module::struct>` is a valid event type.

On 2024-02-08, testnet transaction 890026709 (https://explorer.aptoslabs.com/txn/890026709/events?network=testnet emitted such) emitted a vector of struct event type and crashed an Econia processor. Diagnosis revealed that the processor needs to be updated to ignore event types that are not of the form `address::module::struct`, since Econia events necessarily have only this type.

Update the processor to ignore event types that are not of the form `address::module::struct` before checking if the address is the Econia address.