### PR TITLE
[ECO-1918] restart from last indexed transaction

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -38,7 +38,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         netcat \
         libdw-dev \
         libpq-dev \
-        curl
+        curl \
+        postgresql-client
 
 ENV RUST_LOG_FORMAT=json
 

--- a/rust/start.sh
+++ b/rust/start.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+psql "$DATABASE_URL" -c '\copy processor_status to /processor_status.csv csv'
+
+if [ -s "/processor_status.csv" ];then
+    export STARTING_VERSION="$(cut -d, -f2 /processor_status.csv)"
+fi
+
+rm /processor_status.csv
+
 echo "health_check_port: 8084
 server_config:
   processor_config:


### PR DESCRIPTION
Update the processor startup to only start indexing from latest txn version number after a panic