### PR TITLE
[ECO-2094] Add assorted features to initial version of processor

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/constants.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/constants.rs
@@ -30,16 +30,15 @@ pub const INITIAL_MARKET_NONCE: i64 = 1;
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::util::standardize_address;
+    use crate::db::common::models::emojicoin_models::utils::normalize_address;
 
     #[test]
     fn ensure_contract_address_is_standardized() {
-        if standardize_address(env!("EMOJICOIN_MODULE_ADDRESS")) != env!("EMOJICOIN_MODULE_ADDRESS")
-        {
+        if normalize_address(env!("EMOJICOIN_MODULE_ADDRESS")) != env!("EMOJICOIN_MODULE_ADDRESS") {
             panic!(
                 "The non-standardized contract address: {} is invalid because it doesn't match the standardized address: {}",
                 env!("EMOJICOIN_MODULE_ADDRESS"),
-                standardize_address(env!("EMOJICOIN_MODULE_ADDRESS"))
+                normalize_address(env!("EMOJICOIN_MODULE_ADDRESS"))
             );
         }
     }

--- a/rust/processor/src/db/common/models/emojicoin_models/enums.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/enums.rs
@@ -1,7 +1,17 @@
-use super::{constants::{
-    CHAT_EVENT, GLOBAL_STATE_EVENT, LIQUIDITY_EVENT, MARKET_REGISTRATION_EVENT, MARKET_RESOURCE,
-    PERIODIC_STATE_EVENT, STATE_EVENT, SWAP_EVENT,
-}, json_types::{EventWithMarket, GlobalStateEvent}, models::{chat_event::ChatEventModel, global_state_event::GlobalStateEventModel, liquidity_event::LiquidityEventModel, market_latest_state_event::MarketLatestStateEventModel, market_registration_event::MarketRegistrationEventModel, periodic_state_event::PeriodicStateEventModel, swap_event::SwapEventModel}};
+use super::{
+    constants::{
+        CHAT_EVENT, GLOBAL_STATE_EVENT, LIQUIDITY_EVENT, MARKET_REGISTRATION_EVENT,
+        MARKET_RESOURCE, PERIODIC_STATE_EVENT, STATE_EVENT, SWAP_EVENT,
+    },
+    json_types::{EventWithMarket, GlobalStateEvent},
+    models::{
+        chat_event::ChatEventModel, global_state_event::GlobalStateEventModel,
+        liquidity_event::LiquidityEventModel,
+        market_latest_state_event::MarketLatestStateEventModel,
+        market_registration_event::MarketRegistrationEventModel,
+        periodic_state_event::PeriodicStateEventModel, swap_event::SwapEventModel,
+    },
+};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(
@@ -54,9 +64,7 @@ where
     s.serialize_i16(element.into())
 }
 
-pub fn deserialize_state_trigger<'de, D>(
-    deserializer: D,
-) -> core::result::Result<Trigger, D::Error>
+pub fn deserialize_state_trigger<'de, D>(deserializer: D) -> core::result::Result<Trigger, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -182,17 +190,15 @@ pub enum EmojicoinDbEventType {
 impl From<&EmojicoinEvent> for EmojicoinEventType {
     fn from(value: &EmojicoinEvent) -> Self {
         match value {
-            EmojicoinEvent::EventWithMarket(e) => {
-                match e {
-                    EventWithMarket::PeriodicState(_) => EmojicoinEventType::PeriodicState,
-                    EventWithMarket::State(_) => EmojicoinEventType::State,
-                    EventWithMarket::Swap(_) => EmojicoinEventType::Swap,
-                    EventWithMarket::Chat(_) => EmojicoinEventType::Chat,
-                    EventWithMarket::Liquidity(_) => EmojicoinEventType::Liquidity,
-                    EventWithMarket::MarketRegistration(_) => EmojicoinEventType::MarketRegistration,
-                }
+            EmojicoinEvent::EventWithMarket(e) => match e {
+                EventWithMarket::PeriodicState(_) => EmojicoinEventType::PeriodicState,
+                EventWithMarket::State(_) => EmojicoinEventType::State,
+                EventWithMarket::Swap(_) => EmojicoinEventType::Swap,
+                EventWithMarket::Chat(_) => EmojicoinEventType::Chat,
+                EventWithMarket::Liquidity(_) => EmojicoinEventType::Liquidity,
+                EventWithMarket::MarketRegistration(_) => EmojicoinEventType::MarketRegistration,
             },
-            EmojicoinEvent::EventWithoutMarket(_) => EmojicoinEventType::GlobalState
+            EmojicoinEvent::EventWithoutMarket(_) => EmojicoinEventType::GlobalState,
         }
     }
 }
@@ -224,5 +230,43 @@ impl EmojicoinTypeTag {
             str if str == MARKET_RESOURCE.as_str() => Some(Self::Market),
             _ => None,
         }
+    }
+}
+
+impl EmojicoinDbEvent {
+    pub fn from_market_registration_events(events: &[MarketRegistrationEventModel]) -> Vec<Self> {
+        events
+            .iter()
+            .cloned()
+            .map(Self::MarketRegistration)
+            .collect()
+    }
+
+    pub fn from_swap_events(events: &[SwapEventModel]) -> Vec<Self> {
+        events.iter().cloned().map(Self::Swap).collect()
+    }
+
+    pub fn from_chat_events(events: &[ChatEventModel]) -> Vec<Self> {
+        events.iter().cloned().map(Self::Chat).collect()
+    }
+
+    pub fn from_liquidity_events(events: &[LiquidityEventModel]) -> Vec<Self> {
+        events.iter().cloned().map(Self::Liquidity).collect()
+    }
+
+    pub fn from_periodic_state_events(events: &[PeriodicStateEventModel]) -> Vec<Self> {
+        events.iter().cloned().map(Self::PeriodicState).collect()
+    }
+
+    pub fn from_global_state_events(events: &[GlobalStateEventModel]) -> Vec<Self> {
+        events.iter().cloned().map(Self::GlobalState).collect()
+    }
+
+    pub fn from_market_latest_state_events(events: &[MarketLatestStateEventModel]) -> Vec<Self> {
+        events
+            .iter()
+            .cloned()
+            .map(Self::MarketLatestState)
+            .collect()
     }
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/event_utils.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/event_utils.rs
@@ -69,8 +69,11 @@ impl EventGroupBuilder {
     }
 
     pub fn add_event(&mut self, event: EventWithMarket) {
-        debug_assert!(event.get_market_id() == self.market_id);
-        debug_assert!(event.get_market_nonce() == self.market_nonce);
+        if event.get_market_id() != self.market_id || event.get_market_nonce() != self.market_nonce
+        {
+            let msg = "EventGroupBuilder can only have one market_id and market_nonce.";
+            panic!("{} New event: {:?} Initial event: {:?}", msg, event, self);
+        }
         match event {
             EventWithMarket::MarketRegistration(e) => {
                 self.add_bump(BumpEvent::MarketRegistration(e))
@@ -98,7 +101,13 @@ impl EventGroupBuilder {
     }
 
     pub fn add_periodic_state(&mut self, periodic_state_event: PeriodicStateEvent) {
-        debug_assert!(self.periodic_state_events.len() < 7);
+        if self.periodic_state_events.len() >= 7 {
+            let msg = "EventGroups can only have up to seven PeriodicStateEvents.";
+            panic!(
+                "{} Existing {:?}, attemped to add: {:?}",
+                msg, self.periodic_state_events, periodic_state_event
+            );
+        }
         self.periodic_state_events.push(periodic_state_event);
     }
 

--- a/rust/processor/src/db/common/models/emojicoin_models/event_utils.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/event_utils.rs
@@ -104,7 +104,7 @@ impl EventGroupBuilder {
         if self.periodic_state_events.len() >= 7 {
             let msg = "EventGroups can only have up to seven PeriodicStateEvents.";
             panic!(
-                "{} Existing {:?}, attemped to add: {:?}",
+                "{} Existing {:?}, attempted to add: {:?}",
                 msg, self.periodic_state_events, periodic_state_event
             );
         }

--- a/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -1,15 +1,16 @@
 use anyhow::{Context, Result};
 use aptos_protos::transaction::v1::WriteResource;
 use bigdecimal::BigDecimal;
-use num::FromPrimitive;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
     db::common::models::emojicoin_models::enums::{
-        deserialize_state_period, serialize_state_period, deserialize_state_trigger, serialize_state_trigger,
+        deserialize_state_period, deserialize_state_trigger, serialize_state_period,
+        serialize_state_trigger,
     },
     utils::util::{
-        serialize_to_string, deserialize_from_string, hex_to_raw_bytes, standardize_address, AggregatorSnapshot,
+        deserialize_from_string, hex_to_raw_bytes, serialize_to_string, standardize_address,
+        AggregatorSnapshot,
     },
 };
 
@@ -49,8 +50,9 @@ where
     S: Serializer,
 {
     (AggregatorSnapshot {
-        value: element.clone()
-    }).serialize(s)
+        value: element.clone(),
+    })
+    .serialize(s)
 }
 
 pub fn deserialize_aggregator_snapshot_u128<'de, D>(
@@ -69,7 +71,8 @@ where
 {
     (AggregatorSnapshotI64 {
         value: element.clone(),
-    }).serialize(s)
+    })
+    .serialize(s)
 }
 
 pub fn deserialize_aggregator_snapshot_u64<'de, D>(
@@ -244,6 +247,10 @@ pub struct SwapEvent {
     pub pool_fee: i64,
     pub starts_in_bonding_curve: bool,
     pub results_in_state_transition: bool,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub balance_as_fraction_of_circulating_supply_before_q64: BigDecimal,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub balance_as_fraction_of_circulating_supply_after_q64: BigDecimal,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -404,10 +411,10 @@ pub struct LiquidityEvent {
     pub liquidity_provided: bool,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub pro_rata_base_donation_claim_amount: i64,
+    pub base_donation_claim_amount: i64,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub pro_rata_quote_donation_claim_amount: i64,
+    pub quote_donation_claim_amount: i64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -9,12 +9,14 @@ use crate::{
         serialize_state_trigger,
     },
     utils::util::{
-        deserialize_from_string, hex_to_raw_bytes, serialize_to_string, standardize_address,
-        AggregatorSnapshot,
+        deserialize_from_string, hex_to_raw_bytes, serialize_to_string, AggregatorSnapshot,
     },
 };
 
-use super::enums::{EmojicoinTypeTag, Period, Trigger};
+use super::{
+    enums::{EmojicoinTypeTag, Period, Trigger},
+    utils::normalize_address,
+};
 
 pub fn serialize_bytes_to_hex_string<S>(element: &Vec<u8>, s: S) -> Result<S::Ok, S::Error>
 where
@@ -42,7 +44,7 @@ where
     D: Deserializer<'de>,
 {
     let s = <String>::deserialize(deserializer)?;
-    Ok(standardize_address(&s))
+    Ok(normalize_address(&s))
 }
 
 pub fn serialize_aggregator_snapshot_u128<S>(element: &BigDecimal, s: S) -> Result<S::Ok, S::Error>

--- a/rust/processor/src/db/common/models/emojicoin_models/models/liquidity_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/liquidity_event.rs
@@ -29,8 +29,8 @@ pub struct LiquidityEventModel {
     pub quote_amount: i64,
     pub lp_coin_amount: i64,
     pub liquidity_provided: bool,
-    pub pro_rata_base_donation_claim_amount: i64,
-    pub pro_rata_quote_donation_claim_amount: i64,
+    pub base_donation_claim_amount: i64,
+    pub quote_donation_claim_amount: i64,
 
     // State event data.
     pub clamm_virtual_reserves_base: i64,
@@ -82,8 +82,8 @@ impl LiquidityEventModel {
             quote_amount,
             lp_coin_amount,
             liquidity_provided,
-            pro_rata_base_donation_claim_amount,
-            pro_rata_quote_donation_claim_amount,
+            base_donation_claim_amount,
+            quote_donation_claim_amount,
             ..
         } = liquidity_event;
 
@@ -107,8 +107,8 @@ impl LiquidityEventModel {
             quote_amount,
             lp_coin_amount,
             liquidity_provided,
-            pro_rata_base_donation_claim_amount,
-            pro_rata_quote_donation_claim_amount,
+            base_donation_claim_amount,
+            quote_donation_claim_amount,
 
             // State event data.
             clamm_virtual_reserves_base: clamm.base,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/swap_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/swap_event.rs
@@ -37,6 +37,8 @@ pub struct SwapEventModel {
     pub pool_fee: i64,
     pub starts_in_bonding_curve: bool,
     pub results_in_state_transition: bool,
+    pub balance_as_fraction_of_circulating_supply_before_q64: BigDecimal,
+    pub balance_as_fraction_of_circulating_supply_after_q64: BigDecimal,
 
     // State event data.
     pub clamm_virtual_reserves_base: i64,
@@ -74,6 +76,28 @@ impl SwapEventModel {
             ..
         } = state_event;
 
+        let SwapEvent {
+            market_id,
+            market_nonce,
+            swapper,
+            integrator,
+            integrator_fee,
+            input_amount,
+            is_sell,
+            integrator_fee_rate_bps,
+            net_proceeds,
+            base_volume,
+            quote_volume,
+            avg_execution_price_q64,
+            pool_fee,
+            starts_in_bonding_curve,
+            results_in_state_transition,
+            time,
+            balance_as_fraction_of_circulating_supply_before_q64,
+            balance_as_fraction_of_circulating_supply_after_q64,
+            ..
+        } = swap_event;
+
         SwapEventModel {
             // Transaction metadata.
             transaction_version: txn_info.version,
@@ -82,26 +106,28 @@ impl SwapEventModel {
             transaction_timestamp: txn_info.timestamp,
 
             // Market and state metadata.
-            market_id: swap_event.market_id,
+            market_id,
             symbol_bytes: market_metadata.emoji_bytes,
-            bump_time: micros_to_naive_datetime(swap_event.time),
-            market_nonce: swap_event.market_nonce,
+            bump_time: micros_to_naive_datetime(time),
+            market_nonce,
             trigger: state_metadata.trigger,
 
             // Swap event data.
-            swapper: swap_event.swapper,
-            integrator: swap_event.integrator,
-            integrator_fee: swap_event.integrator_fee,
-            input_amount: swap_event.input_amount,
-            is_sell: swap_event.is_sell,
-            integrator_fee_rate_bps: swap_event.integrator_fee_rate_bps,
-            net_proceeds: swap_event.net_proceeds,
-            base_volume: swap_event.base_volume,
-            quote_volume: swap_event.quote_volume,
-            avg_execution_price_q64: swap_event.avg_execution_price_q64,
-            pool_fee: swap_event.pool_fee,
-            starts_in_bonding_curve: swap_event.starts_in_bonding_curve,
-            results_in_state_transition: swap_event.results_in_state_transition,
+            swapper,
+            integrator,
+            integrator_fee,
+            input_amount,
+            is_sell,
+            integrator_fee_rate_bps,
+            net_proceeds,
+            base_volume,
+            quote_volume,
+            avg_execution_price_q64,
+            pool_fee,
+            starts_in_bonding_curve,
+            results_in_state_transition,
+            balance_as_fraction_of_circulating_supply_before_q64,
+            balance_as_fraction_of_circulating_supply_after_q64,
 
             // State event data.
             clamm_virtual_reserves_base: clamm.base,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/user_liquidity_pools.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/user_liquidity_pools.rs
@@ -24,8 +24,8 @@ pub struct UserLiquidityPoolsModel {
     pub quote_amount: i64,
     pub lp_coin_amount: i64,
     pub liquidity_provided: bool,
-    pub pro_rata_base_donation_claim_amount: i64,
-    pub pro_rata_quote_donation_claim_amount: i64,
+    pub base_donation_claim_amount: i64,
+    pub quote_donation_claim_amount: i64,
 }
 
 impl From<LiquidityEventModel> for UserLiquidityPoolsModel {
@@ -43,8 +43,8 @@ impl From<LiquidityEventModel> for UserLiquidityPoolsModel {
             quote_amount: evt.quote_amount,
             lp_coin_amount: evt.lp_coin_amount,
             liquidity_provided: evt.liquidity_provided,
-            pro_rata_base_donation_claim_amount: evt.pro_rata_base_donation_claim_amount,
-            pro_rata_quote_donation_claim_amount: evt.pro_rata_quote_donation_claim_amount,
+            base_donation_claim_amount: evt.base_donation_claim_amount,
+            quote_donation_claim_amount: evt.quote_donation_claim_amount,
         }
     }
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/parsers/market_resource.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/parsers/market_resource.rs
@@ -1,8 +1,7 @@
 use aptos_protos::transaction::v1::{write_set_change::Change as WriteSetChangeEnum, Transaction};
 
-use crate::{
-    db::common::models::emojicoin_models::json_types::MarketResource,
-    utils::util::standardize_address,
+use crate::db::common::models::emojicoin_models::{
+    json_types::MarketResource, utils::normalize_address,
 };
 
 impl MarketResource {
@@ -14,7 +13,7 @@ impl MarketResource {
             .iter()
             .find_map(|wsc| {
                 if let WriteSetChangeEnum::WriteResource(resource) = &wsc.change.as_ref().unwrap() {
-                    if standardize_address(resource.address.as_str()) == market_address {
+                    if normalize_address(resource.address.as_str()) == market_address {
                         Self::from_write_resource(resource).ok().flatten()
                     } else {
                         None

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
@@ -130,10 +130,8 @@ pub fn insert_user_liquidity_pools_query(
                 quote_amount.eq(excluded(quote_amount)),
                 lp_coin_amount.eq(excluded(lp_coin_amount)),
                 liquidity_provided.eq(excluded(liquidity_provided)),
-                pro_rata_base_donation_claim_amount
-                    .eq(excluded(pro_rata_base_donation_claim_amount)),
-                pro_rata_quote_donation_claim_amount
-                    .eq(excluded(pro_rata_quote_donation_claim_amount)),
+                base_donation_claim_amount.eq(excluded(base_donation_claim_amount)),
+                quote_donation_claim_amount.eq(excluded(quote_donation_claim_amount)),
             ))
             .filter(market_nonce.le(excluded(market_nonce))),
         None,

--- a/rust/processor/src/db/common/models/emojicoin_models/tests.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/tests.rs
@@ -128,8 +128,8 @@ mod json_tests {
             "lp_coin_amount": "4272180527",
             "market_id": "328",
             "market_nonce": "40278",
-            "pro_rata_base_donation_claim_amount": "0",
-            "pro_rata_quote_donation_claim_amount": "0",
+            "base_donation_claim_amount": "0",
+            "quote_donation_claim_amount": "0",
             "provider": "0x000006d68589500aa64d92f4f0e14d2f9d8075d003b8adf1e90ae6037f100000",
             "quote_amount": "100000000",
             "time": "1723246374791035"
@@ -145,8 +145,8 @@ mod json_tests {
             assert_eq!(e.lp_coin_amount, 4272180527);
             assert_eq!(e.base_amount, 1639206334780);
             assert_eq!(e.quote_amount, 100000000);
-            assert_eq!(e.pro_rata_base_donation_claim_amount, 0);
-            assert_eq!(e.pro_rata_quote_donation_claim_amount, 0);
+            assert_eq!(e.base_donation_claim_amount, 0);
+            assert_eq!(e.quote_donation_claim_amount, 0);
             assert_eq!(e.market_id, 328);
             assert_eq!(e.time, 1723246374791035);
             assert_eq!(

--- a/rust/processor/src/db/common/models/emojicoin_models/tests.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/tests.rs
@@ -60,7 +60,7 @@ mod json_tests {
         if let Some(EventWithMarket::State(e)) = state_event {
             assert_eq!(
                 e.market_metadata.market_address,
-                "0x066fb901175394d0883e28262c4c40cb8228e47a36e6a813d5117805c3c26a5c"
+                "0x66fb901175394d0883e28262c4c40cb8228e47a36e6a813d5117805c3c26a5c"
             );
             assert_eq!(e.market_metadata.market_id, 328);
             assert_eq!(e.state_metadata.trigger, Trigger::ProvideLiquidity);
@@ -109,7 +109,7 @@ mod json_tests {
         if let Some(EventWithMarket::PeriodicState(e)) = periodic_state_event {
             assert_eq!(
                 e.market_metadata.market_address,
-                "0x00000000175394d0883e28262c4c40cb8228e47a36e6a813d5117805c3c26a5c"
+                "0x175394d0883e28262c4c40cb8228e47a36e6a813d5117805c3c26a5c"
             );
             assert!(!e.starts_in_bonding_curve);
             assert_eq!(e.close_price_q64, 1128118906863219_i64.into());
@@ -151,7 +151,7 @@ mod json_tests {
             assert_eq!(e.time, 1723246374791035);
             assert_eq!(
                 e.provider,
-                "0x000006d68589500aa64d92f4f0e14d2f9d8075d003b8adf1e90ae6037f100000"
+                "0x6d68589500aa64d92f4f0e14d2f9d8075d003b8adf1e90ae6037f100000"
             );
         } else {
             panic!("Failed to parse periodic state event");
@@ -176,6 +176,8 @@ mod json_tests {
             "quote_volume": "99000000",
             "results_in_state_transition": false,
             "starts_in_bonding_curve": true,
+            "balance_as_fraction_of_circulating_supply_before_q64": "0",
+            "balance_as_fraction_of_circulating_supply_after_q64": "1",
             "swapper": "0xbad225596d685895aa64d92f4f0e14d2f9d8075d3b8adf1e90ae6037f1fcbabe",
             "time": "1723253663706846"
           }
@@ -196,6 +198,14 @@ mod json_tests {
             assert_eq!(e.market_id, 3523452345);
             assert_eq!(e.market_nonce, 2);
             assert_eq!(e.time, 1723253663706846);
+            assert_eq!(
+                e.balance_as_fraction_of_circulating_supply_before_q64,
+                0.into()
+            );
+            assert_eq!(
+                e.balance_as_fraction_of_circulating_supply_after_q64,
+                1.into()
+            );
         } else {
             panic!("Failed to parse periodic state event");
         }

--- a/rust/processor/src/db/common/models/emojicoin_models/utils.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/utils.rs
@@ -11,3 +11,84 @@ pub fn within_past_day(time: NaiveDateTime) -> bool {
 
     time.and_utc() > one_day_ago
 }
+
+// Removes all leading zeros from an address, adds an "0x" prefix, and converts the address to lowercase.
+// Note this does nearly the opposite of what `standardize_address` does, since it removes leading zeros,
+// while `standardize_address` pads addresses with leading zeros to 64 characters.
+pub fn normalize_address(s: &str) -> String {
+    let res = s
+        .strip_prefix("0x")
+        .unwrap_or(s)
+        .trim_start_matches('0')
+        .to_lowercase();
+    format!("0x{}", res)
+}
+
+#[cfg(test)]
+mod utils_tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_leading_zeros() {
+        assert_eq!(normalize_address("0x"), "0x");
+        assert_eq!(normalize_address("0x0123"), "0x123");
+        assert_eq!(normalize_address("0x00123"), "0x123");
+        assert_eq!(
+            normalize_address("0x000000000000000000000000000000000000000000000000123"),
+            "0x123"
+        );
+        assert_eq!(
+            normalize_address("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            "0x1"
+        );
+        assert_eq!(
+            normalize_address("0x0000000000000000000000000000000000000000000000000000000000000002"),
+            "0x2"
+        );
+        assert_eq!(
+            normalize_address("0x0000000000000000000000000000000000000000000000000000000000000003"),
+            "0x3"
+        );
+        assert_eq!(
+            normalize_address("0x000000000000000000000000000000000000000000000000000000000000000a"),
+            "0xa"
+        );
+        assert_eq!(
+            normalize_address("0x000000000000000000000000000000000000000000000000000000000000000b"),
+            "0xb"
+        );
+        assert_eq!(
+            normalize_address("0x000000000000000000000000000000000000000000000000000000000000000c"),
+            "0xc"
+        );
+        assert_eq!(
+            normalize_address("0x000000000000000000000000000000000000000000000000000000000000000f"),
+            "0xf"
+        );
+    }
+
+    #[test]
+    fn test_upper_leading_zeros() {
+        assert_eq!(normalize_address("0x001ABC23"), "0x1abc23");
+        assert_eq!(
+            normalize_address("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            "0x1"
+        );
+        assert_eq!(
+            normalize_address("0x000000000000000000000000000000000000000000000000000000000000000A"),
+            "0xa"
+        );
+        assert_eq!(
+            normalize_address("0x000000000000000000000000000000000000000000000000000000000000000C"),
+            "0xc"
+        );
+        assert_eq!(
+            normalize_address("0x000000000000000000000000000000000000000000000000000000000000000F"),
+            "0xf"
+        );
+        assert_eq!(
+            normalize_address("0x000000000001000000A000000000B00000c000000000000D00000e000000000F"),
+            "0x1000000a000000000b00000c000000000000d00000e000000000f"
+        );
+    }
+}

--- a/rust/processor/src/db/postgres/migrations/2024-08-13-014340_add_latest_market_state/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-13-014340_add_latest_market_state/down.sql
@@ -1,6 +1,6 @@
 -- This file should undo anything in `up.sql`
 
-DROP INDEX mkts_in_bonding_curve_idx;
+DROP INDEX mkts_out_of_bonding_curve_idx;
 DROP INDEX user_lp_pools_idx;
 DROP INDEX unique_mkts_idx;
 

--- a/rust/processor/src/db/postgres/migrations/2024-08-13-014340_add_latest_market_state/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-13-014340_add_latest_market_state/down.sql
@@ -1,6 +1,6 @@
 -- This file should undo anything in `up.sql`
 
-DROP INDEX mkts_out_of_bonding_curve_idx;
+DROP INDEX mkts_post_bonding_curve_idx;
 DROP INDEX user_lp_pools_idx;
 DROP INDEX unique_mkts_idx;
 

--- a/rust/processor/src/db/postgres/migrations/2024-08-13-014340_add_latest_market_state/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-13-014340_add_latest_market_state/up.sql
@@ -47,7 +47,7 @@ CREATE TABLE market_latest_state_event (
   PRIMARY KEY (market_id)
 );
 
-CREATE INDEX mkts_out_of_bonding_curve_idx
+CREATE INDEX mkts_post_bonding_curve_idx
 ON market_latest_state_event (market_id)
 WHERE in_bonding_curve = FALSE;
 

--- a/rust/processor/src/db/postgres/migrations/2024-08-13-014340_add_latest_market_state/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-13-014340_add_latest_market_state/up.sql
@@ -47,9 +47,9 @@ CREATE TABLE market_latest_state_event (
   PRIMARY KEY (market_id)
 );
 
-CREATE INDEX mkts_in_bonding_curve_idx
-ON market_latest_state_event (in_bonding_curve, market_id)
-WHERE in_bonding_curve = TRUE;
+CREATE INDEX mkts_out_of_bonding_curve_idx
+ON market_latest_state_event (market_id)
+WHERE in_bonding_curve = FALSE;
 
 CREATE INDEX unique_mkts_idx
 ON market_latest_state_event (market_id);

--- a/rust/processor/src/db/postgres/migrations/2024-08-14-015329_add_daily_volume_and_tvl_growth/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-14-015329_add_daily_volume_and_tvl_growth/down.sql
@@ -1,8 +1,5 @@
 -- This file should undo anything in `up.sql`
 
-DROP FUNCTION assert_arrays_equal_length(BIGINT[], NUMERIC[]);
-DROP FUNCTION assert_arrays_equal_length(BIGINT[], BIGINT[]);
-
 DROP INDEX mkt_1m_prds_last_24h_idx;
 DROP VIEW market_daily_volume;
 DROP TABLE market_1m_periods_in_last_day;

--- a/rust/processor/src/db/postgres/migrations/2024-08-14-015329_add_daily_volume_and_tvl_growth/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-14-015329_add_daily_volume_and_tvl_growth/up.sql
@@ -1,21 +1,5 @@
 -- Your SQL goes here
 
-CREATE OR REPLACE FUNCTION assert_arrays_equal_length(BIGINT[], NUMERIC[]) RETURNS void AS $$
-BEGIN
-    IF array_length($1, 1) != array_length($2, 1) THEN
-        RAISE EXCEPTION 'Arrays are not of equal length';
-    END IF;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION assert_arrays_equal_length(BIGINT[], BIGINT[]) RETURNS void AS $$
-BEGIN
-    IF array_length($1, 1) != array_length($2, 1) THEN
-        RAISE EXCEPTION 'Arrays are not of equal length';
-    END IF;
-END;
-$$ LANGUAGE plpgsql;
-
 CREATE TABLE market_1m_periods_in_last_day (
     market_id BIGINT NOT NULL,
     inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),

--- a/rust/processor/src/db/postgres/migrations/2024-08-21-001328_update_swap_and_liquidity_fields/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-21-001328_update_swap_and_liquidity_fields/down.sql
@@ -1,0 +1,19 @@
+-- This file should undo anything in `up.sql`
+
+
+ALTER TABLE swap_events
+  DROP COLUMN balance_as_fraction_of_circulating_supply_before_q64,
+  DROP COLUMN balance_as_fraction_of_circulating_supply_after_q64;
+
+ALTER TABLE liquidity_events
+RENAME COLUMN base_donation_claim_amount TO pro_rata_base_donation_claim_amount;
+
+ALTER TABLE liquidity_events
+RENAME COLUMN quote_donation_claim_amount TO pro_rata_quote_donation_claim_amount;
+
+ALTER TABLE user_liquidity_pools
+RENAME COLUMN base_donation_claim_amount TO pro_rata_base_donation_claim_amount;
+
+ALTER TABLE user_liquidity_pools
+RENAME COLUMN quote_donation_claim_amount TO pro_rata_quote_donation_claim_amount;
+

--- a/rust/processor/src/db/postgres/migrations/2024-08-21-001328_update_swap_and_liquidity_fields/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-21-001328_update_swap_and_liquidity_fields/up.sql
@@ -1,0 +1,17 @@
+-- Your SQL goes here
+
+ALTER TABLE swap_events
+ADD COLUMN balance_as_fraction_of_circulating_supply_before_q64 NUMERIC NOT NULL,
+ADD COLUMN balance_as_fraction_of_circulating_supply_after_q64 NUMERIC NOT NULL;
+
+ALTER TABLE liquidity_events
+RENAME COLUMN pro_rata_base_donation_claim_amount TO base_donation_claim_amount;
+
+ALTER TABLE liquidity_events
+RENAME COLUMN pro_rata_quote_donation_claim_amount TO quote_donation_claim_amount;
+
+ALTER TABLE user_liquidity_pools
+RENAME COLUMN pro_rata_base_donation_claim_amount TO base_donation_claim_amount;
+
+ALTER TABLE user_liquidity_pools
+RENAME COLUMN pro_rata_quote_donation_claim_amount TO quote_donation_claim_amount;

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -966,8 +966,8 @@ diesel::table! {
         quote_amount -> Int8,
         lp_coin_amount -> Int8,
         liquidity_provided -> Bool,
-        pro_rata_base_donation_claim_amount -> Int8,
-        pro_rata_quote_donation_claim_amount -> Int8,
+        base_donation_claim_amount -> Int8,
+        quote_donation_claim_amount -> Int8,
         clamm_virtual_reserves_base -> Int8,
         clamm_virtual_reserves_quote -> Int8,
         cpamm_real_reserves_base -> Int8,
@@ -1287,6 +1287,8 @@ diesel::table! {
         instantaneous_stats_total_value_locked -> Numeric,
         instantaneous_stats_market_cap -> Numeric,
         instantaneous_stats_fully_diluted_value -> Numeric,
+        balance_as_fraction_of_circulating_supply_before_q64 -> Numeric,
+        balance_as_fraction_of_circulating_supply_after_q64 -> Numeric,
     }
 }
 
@@ -1563,8 +1565,8 @@ diesel::table! {
         quote_amount -> Int8,
         lp_coin_amount -> Int8,
         liquidity_provided -> Bool,
-        pro_rata_base_donation_claim_amount -> Int8,
-        pro_rata_quote_donation_claim_amount -> Int8,
+        base_donation_claim_amount -> Int8,
+        quote_donation_claim_amount -> Int8,
     }
 }
 


### PR DESCRIPTION
- [x] Remove `debug_assert` statements, replace them with `panic`s since it indicates the data is corrupted/incorrect
- [x] Address comments on `in_bonding_curve` for `mkts_in_bonding_curve_idx`: note that in addition to removing `in_bonding_curve` from the index that this changed to `mkts_post_bonding_curve_idx`, `WHERE in_bonding_curve = FALSE`, because the initial implementation was useless since most markets would be in the bonding curve and the index wouldn't even get used
- [x] Sanitize all addresses and normalize them to remove leading zeros
