### PR TITLE
[ECO-2132] Add index for latest state; normalize `sender` address

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/models/market_latest_state_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/market_latest_state_event.rs
@@ -123,8 +123,7 @@ impl MarketLatestStateEventModel {
             last_swap_time: micros_to_naive_datetime(last_swap.time),
 
             daily_tvl_per_lp_coin_growth_q64: calculate_tvl_growth(tracker_1d),
-            in_bonding_curve: tracker_1m.starts_in_bonding_curve
-                || tracker_1m.ends_in_bonding_curve,
+            in_bonding_curve: tracker_1m.ends_in_bonding_curve,
             volume_in_1m_state_tracker: tracker_1m.volume_quote,
         }
     }

--- a/rust/processor/src/db/postgres/migrations/2024-08-25-070629_add_latest_states_index/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-25-070629_add_latest_states_index/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DROP INDEX latest_states_idx;

--- a/rust/processor/src/db/postgres/migrations/2024-08-25-070629_add_latest_states_index/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-25-070629_add_latest_states_index/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+
+CREATE INDEX latest_states_idx
+ON market_latest_state_event (bump_time DESC)
+INCLUDE (market_id);

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -22,6 +22,7 @@ use crate::{
             insert_periodic_state_events_query, insert_swap_events_query,
             insert_user_liquidity_pools_query,
         },
+        utils::normalize_address,
     },
     emojicoin_dot_fun::EmojicoinDbEvent,
     gap_detectors::ProcessingResult,
@@ -29,7 +30,7 @@ use crate::{
     utils::{
         counters::PROCESSOR_UNKNOWN_TYPE_COUNT,
         database::{execute_in_chunks, get_config_table_chunk_size, ArcDbPool},
-        util::{get_entry_function_from_user_request, parse_timestamp, standardize_address},
+        util::{get_entry_function_from_user_request, parse_timestamp},
     },
 };
 use ahash::AHashMap;
@@ -254,7 +255,7 @@ impl ProcessorTrait for EmojicoinProcessor {
                 let entry_function = get_entry_function_from_user_request(user_request);
                 let txn_info = TxnInfo {
                     version: txn_version,
-                    sender: standardize_address(user_request.sender.as_ref()),
+                    sender: normalize_address(user_request.sender.as_ref()),
                     entry_function,
                     timestamp: parse_timestamp(txn.timestamp.as_ref().unwrap(), txn_version),
                 };


### PR DESCRIPTION
I forgot to normalize the sender address because it's created in the processor and not while deserializing.

- [x] Normalize the sender address
- [x] Ensure standardize_address isn't used anywhere else in our processor code
- [x] Add an index for latest state, aka sorting by bump order
- [x] Fix the incorrect `in_bonding_curve` logic
