### PR TITLE
[ECO-2172] Fix nightly/stable incompatibility

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,8 +13,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libdw-dev
-    - name: 'Use nigthly toolchain'
-      run: rustup default nightly && rustup component add rustfmt && rustup component add clippy
     - uses: 'pre-commit/action@v3.0.0'
       with:
         extra_args: '--all-files --config cfg/pre-commit-config.yaml --verbose'

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -1,0 +1,21 @@
+---
+env:
+  PYTHON_VERSION: '3.10'
+jobs:
+  check-formatting:
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: 'actions/checkout@v3'
+    - name: 'Use nigthly toolchain'
+      run: rustup default nightly && rustup component add rustfmt
+    - name: 'Run cargo fmt'
+      run: cargo fmt --check
+      working-directory: rust
+name: 'Rust'
+'on':
+  pull_request: null
+  push:
+    branches:
+    - 'main'
+  workflow_dispatch: null
+...

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -27,12 +27,6 @@ repos:
     - '--deny'
     - 'clippy::all'
     id: 'clippy'
-  -
-    args:
-    - '--manifest-path'
-    - 'rust/processor/Cargo.toml'
-    - '--'
-    id: 'fmt'
   repo: 'https://github.com/doublify/pre-commit-rust'
   rev: 'v1.0'
 ...

--- a/rust/server-framework/src/lib.rs
+++ b/rust/server-framework/src/lib.rs
@@ -9,7 +9,7 @@ use prometheus::{Encoder, TextEncoder};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[cfg(target_os = "linux")]
 use std::convert::Infallible;
-use std::{fs::File, io::Read, panic::PanicHookInfo, path::PathBuf, process};
+use std::{fs::File, io::Read, panic::PanicInfo, path::PathBuf, process};
 use tokio::runtime::Handle;
 use tracing::error;
 use tracing_subscriber::EnvFilter;
@@ -111,14 +111,14 @@ pub struct CrashInfo {
 /// ensure that all subsequent thread panics (even Tokio threads) will report the
 /// details/backtrace and then exit.
 pub fn setup_panic_handler() {
-    std::panic::set_hook(Box::new(move |pi: &PanicHookInfo<'_>| {
+    std::panic::set_hook(Box::new(move |pi: &PanicInfo<'_>| {
         handle_panic(pi);
     }));
 }
 
 // Formats and logs panic information
-fn handle_panic(panic_info: &PanicHookInfo<'_>) {
-    // The Display formatter for a PanicHookInfo contains the message, payload and location.
+fn handle_panic(panic_info: &PanicInfo<'_>) {
+    // The Display formatter for a PanicInfo contains the message, payload and location.
     let details = format!("{}", panic_info);
     let backtrace = format!("{:#?}", Backtrace::new());
     let info = CrashInfo { details, backtrace };


### PR DESCRIPTION
When migrating CI here, I noticed that aptos uses the nightly formatting. This is why I switched the CI to use the nightly toolchain.

Big was my surprise when I realized they use the nightly toolchain for formatting but the stable toolchain for the rest.

This is why we can't have nice things.

So I had to update the code to remove all the new warnings that would appear with the nightly toolchain.

By doing this, I had to remove reference to a struct that is now deprecated, and use a new one (`PanicInfo` -> `PanicHookInfo`). Problem: this is not available on stable.

This breaks the rest of our tooling that uses the stable toolchain.

Solution:

- Run checks with stable
- Run formatting with nightly

This has a few downsides:

- You can't do that from pre-commit, you have to separate things. So now running pre-commit no longer warns about bad formatting.
- You have to manually change toolchains if you want to format locally.
- This is cursed.