### PR TITLE
[ECO-2186] Add market address to market registration events

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/models/chat_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/chat_event.rs
@@ -26,6 +26,7 @@ pub struct ChatEventModel {
     pub bump_time: chrono::NaiveDateTime,
     pub market_nonce: i64,
     pub trigger: enums::Trigger,
+    pub market_address: String,
 
     // Chat event data.
     pub user: String,
@@ -99,6 +100,7 @@ impl ChatEventModel {
             bump_time: micros_to_naive_datetime(state_metadata.bump_time),
             market_nonce: state_metadata.market_nonce,
             trigger: state_metadata.trigger,
+            market_address: market_metadata.market_address,
 
             // Chat event data.
             user,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/liquidity_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/liquidity_event.rs
@@ -26,6 +26,7 @@ pub struct LiquidityEventModel {
     pub bump_time: chrono::NaiveDateTime,
     pub market_nonce: i64,
     pub trigger: enums::Trigger,
+    pub market_address: String,
 
     // Liquidity event data.
     pub provider: String,
@@ -104,6 +105,7 @@ impl LiquidityEventModel {
             bump_time: micros_to_naive_datetime(time),
             market_nonce: liquidity_event.market_nonce,
             trigger: state_metadata.trigger,
+            market_address: market_metadata.market_address,
 
             // Liquidity event data.
             provider,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/market_latest_state_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/market_latest_state_event.rs
@@ -27,6 +27,7 @@ pub struct MarketLatestStateEventModel {
     pub bump_time: chrono::NaiveDateTime,
     pub market_nonce: i64,
     pub trigger: enums::Trigger,
+    pub market_address: String,
 
     // State event data.
     pub clamm_virtual_reserves_base: i64,
@@ -100,6 +101,7 @@ impl MarketLatestStateEventModel {
             bump_time: micros_to_naive_datetime(sequence_info.last_bump_time),
             market_nonce: sequence_info.nonce,
             trigger,
+            market_address: metadata.market_address,
 
             clamm_virtual_reserves_base: clamm_virtual_reserves.base,
             clamm_virtual_reserves_quote: clamm_virtual_reserves.quote,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/market_registration_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/market_registration_event.rs
@@ -25,6 +25,7 @@ pub struct MarketRegistrationEventModel {
     pub bump_time: chrono::NaiveDateTime,
     pub market_nonce: i64,
     pub trigger: enums::Trigger,
+    pub market_address: String,
 
     // Market registration event data.
     pub registrant: String,
@@ -60,6 +61,7 @@ impl MarketRegistrationEventModel {
             bump_time: micros_to_naive_datetime(time),
             market_nonce: state_event.state_metadata.market_nonce,
             trigger: state_event.state_metadata.trigger,
+            market_address: market_metadata.market_address,
 
             // Market registration event data.
             registrant,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/periodic_state_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/periodic_state_event.rs
@@ -23,6 +23,7 @@ pub struct PeriodicStateEventModel {
     // Market metadata.
     pub market_id: i64,
     pub symbol_bytes: Vec<u8>,
+    pub market_address: String,
 
     // State metadata.
     pub emit_time: chrono::NaiveDateTime,
@@ -72,6 +73,7 @@ impl PeriodicStateEventModel {
                 entry_function: txn_info.entry_function.clone(),
                 transaction_timestamp: txn_info.timestamp,
                 market_id: ps_event.market_metadata.market_id,
+                market_address: ps_event.market_metadata.market_address,
                 symbol_bytes: ps_event.market_metadata.emoji_bytes,
                 emit_time: micros_to_naive_datetime(ps_event.periodic_state_metadata.emit_time),
                 market_nonce: ps_event.periodic_state_metadata.emit_market_nonce,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/swap_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/swap_event.rs
@@ -26,6 +26,7 @@ pub struct SwapEventModel {
     pub bump_time: chrono::NaiveDateTime,
     pub market_nonce: i64,
     pub trigger: enums::Trigger,
+    pub market_address: String,
 
     // Swap event data.
     pub swapper: String,
@@ -115,6 +116,7 @@ impl SwapEventModel {
             bump_time: micros_to_naive_datetime(time),
             market_nonce,
             trigger: state_metadata.trigger,
+            market_address: market_metadata.market_address,
 
             // Swap event data.
             swapper,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/user_liquidity_pools.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/user_liquidity_pools.rs
@@ -23,6 +23,7 @@ pub struct UserLiquidityPoolsModel {
     pub bump_time: chrono::NaiveDateTime,
     pub market_nonce: i64,
     pub trigger: enums::Trigger,
+    pub market_address: String,
 
     pub base_amount: i64,
     pub quote_amount: i64,
@@ -76,6 +77,7 @@ impl UserLiquidityPoolsModel {
                             base_donation_claim_amount: evt.base_donation_claim_amount,
                             quote_donation_claim_amount: evt.quote_donation_claim_amount,
                             lp_coin_balance: amount.parse().unwrap(),
+                            market_address: evt.market_address.clone(),
                         })
                     } else {
                         None

--- a/rust/processor/src/db/postgres/migrations/2024-08-08-024053_emojicoin_events/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-08-024053_emojicoin_events/up.sql
@@ -70,6 +70,7 @@ CREATE TABLE periodic_state_events (
   emit_time TIMESTAMP NOT NULL,
   market_nonce BIGINT NOT NULL,
   trigger trigger_type NOT NULL,
+  market_address VARCHAR(66) NOT NULL,
 
   -- Last swap data.
   last_swap_is_sell BOOLEAN NOT NULL,
@@ -140,6 +141,7 @@ CREATE TABLE swap_events (
   bump_time TIMESTAMP NOT NULL,
   market_nonce BIGINT NOT NULL,
   trigger trigger_type NOT NULL,
+  market_address VARCHAR(66) NOT NULL,
 
   -- Swap event data.
   swapper VARCHAR(66) NOT NULL,
@@ -194,6 +196,7 @@ CREATE TABLE chat_events (
   bump_time TIMESTAMP NOT NULL,
   market_nonce BIGINT NOT NULL,
   trigger trigger_type NOT NULL,
+  market_address VARCHAR(66) NOT NULL,
 
   -- Chat event data.
   "user" VARCHAR(66) NOT NULL,
@@ -243,6 +246,7 @@ CREATE TABLE liquidity_events (
   bump_time TIMESTAMP NOT NULL,
   market_nonce BIGINT NOT NULL,
   trigger trigger_type NOT NULL,
+  market_address VARCHAR(66) NOT NULL,
 
   -- Liquidity event data.
   provider VARCHAR(66) NOT NULL,

--- a/rust/processor/src/db/postgres/migrations/2024-08-08-024053_emojicoin_events/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-08-024053_emojicoin_events/up.sql
@@ -116,6 +116,7 @@ CREATE TABLE market_registration_events (
   bump_time TIMESTAMP NOT NULL,
   market_nonce BIGINT NOT NULL,
   trigger trigger_type NOT NULL,
+  market_address VARCHAR(66) NOT NULL,
 
   -- Market registration event data.
   registrant VARCHAR(66) NOT NULL,

--- a/rust/processor/src/db/postgres/migrations/2024-08-13-014340_add_latest_market_state/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-13-014340_add_latest_market_state/up.sql
@@ -14,6 +14,7 @@ CREATE TABLE market_latest_state_event (
   bump_time TIMESTAMP NOT NULL, -- Note that bump and emit time are interchangeable.
   market_nonce BIGINT NOT NULL,
   trigger trigger_type NOT NULL,
+  market_address VARCHAR(66) NOT NULL,
 
   -- State event data.
   clamm_virtual_reserves_base BIGINT NOT NULL,
@@ -66,6 +67,7 @@ CREATE TABLE user_liquidity_pools (
   bump_time TIMESTAMP NOT NULL,
   market_nonce BIGINT NOT NULL,
   trigger trigger_type NOT NULL,
+  market_address VARCHAR(66) NOT NULL,
 
   -- Liquidity event data.
   base_amount BIGINT NOT NULL,

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -1067,6 +1067,8 @@ diesel::table! {
         market_nonce -> Int8,
         trigger -> TriggerType,
         #[max_length = 66]
+        market_address -> Varchar,
+        #[max_length = 66]
         registrant -> Varchar,
         #[max_length = 66]
         integrator -> Varchar,

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -129,6 +129,8 @@ diesel::table! {
         market_nonce -> Int8,
         trigger -> TriggerType,
         #[max_length = 66]
+        market_address -> Varchar,
+        #[max_length = 66]
         user -> Varchar,
         message -> Text,
         user_emojicoin_balance -> Int8,
@@ -961,6 +963,8 @@ diesel::table! {
         market_nonce -> Int8,
         trigger -> TriggerType,
         #[max_length = 66]
+        market_address -> Varchar,
+        #[max_length = 66]
         provider -> Varchar,
         base_amount -> Int8,
         quote_amount -> Int8,
@@ -1021,6 +1025,8 @@ diesel::table! {
         bump_time -> Timestamp,
         market_nonce -> Int8,
         trigger -> TriggerType,
+        #[max_length = 66]
+        market_address -> Varchar,
         clamm_virtual_reserves_base -> Int8,
         clamm_virtual_reserves_quote -> Int8,
         cpamm_real_reserves_base -> Int8,
@@ -1162,6 +1168,8 @@ diesel::table! {
         emit_time -> Timestamp,
         market_nonce -> Int8,
         trigger -> TriggerType,
+        #[max_length = 66]
+        market_address -> Varchar,
         last_swap_is_sell -> Bool,
         last_swap_avg_execution_price_q64 -> Numeric,
         last_swap_base_volume -> Int8,
@@ -1258,6 +1266,8 @@ diesel::table! {
         bump_time -> Timestamp,
         market_nonce -> Int8,
         trigger -> TriggerType,
+        #[max_length = 66]
+        market_address -> Varchar,
         #[max_length = 66]
         swapper -> Varchar,
         #[max_length = 66]
@@ -1563,6 +1573,8 @@ diesel::table! {
         bump_time -> Timestamp,
         market_nonce -> Int8,
         trigger -> TriggerType,
+        #[max_length = 66]
+        market_address -> Varchar,
         base_amount -> Int8,
         quote_amount -> Int8,
         lp_coin_amount -> Int8,


### PR DESCRIPTION
This PR adds a missed field (market address) in the market registration event. It is needed in the frontend AFAIK.

This is modified in place instead of making a new migration as this needs to be present from the start and needs a processor cold upgrade.