### PR TITLE
[ECO-2238] Resolve tvl per lp coin growth q64 issue

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/models/market_latest_state_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/market_latest_state_event.rs
@@ -57,7 +57,7 @@ pub struct MarketLatestStateEventModel {
     pub last_swap_time: chrono::NaiveDateTime,
 
     // Processed data.
-    pub daily_tvl_per_lp_coin_growth_q64: BigDecimal,
+    pub daily_tvl_per_lp_coin_growth: BigDecimal,
     pub in_bonding_curve: bool,
     pub volume_in_1m_state_tracker: BigDecimal,
 }
@@ -131,7 +131,7 @@ impl MarketLatestStateEventModel {
             last_swap_nonce: last_swap.nonce,
             last_swap_time: micros_to_naive_datetime(last_swap.time),
 
-            daily_tvl_per_lp_coin_growth_q64: calculate_tvl_growth(tracker_1d),
+            daily_tvl_per_lp_coin_growth: calculate_tvl_growth(tracker_1d),
             in_bonding_curve: tracker_1m.ends_in_bonding_curve,
             volume_in_1m_state_tracker: tracker_1m.volume_quote,
         }

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
@@ -204,7 +204,7 @@ pub fn insert_market_latest_state_event_query(
                 last_swap_quote_volume.eq(excluded(last_swap_quote_volume)),
                 last_swap_nonce.eq(excluded(last_swap_nonce)),
                 last_swap_time.eq(excluded(last_swap_time)),
-                daily_tvl_per_lp_coin_growth_q64.eq(excluded(daily_tvl_per_lp_coin_growth_q64)),
+                daily_tvl_per_lp_coin_growth.eq(excluded(daily_tvl_per_lp_coin_growth)),
                 in_bonding_curve.eq(excluded(in_bonding_curve)),
                 volume_in_1m_state_tracker.eq(excluded(volume_in_1m_state_tracker)),
             ))

--- a/rust/processor/src/db/postgres/migrations/2024-10-04-105346_fix_tvl_column_name/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-10-04-105346_fix_tvl_column_name/down.sql
@@ -1,0 +1,63 @@
+-- This file should undo anything in `up.sql`
+DROP FUNCTION user_pools(provider text);
+CREATE FUNCTION user_pools(provider text) RETURNS TABLE(
+  transaction_version BIGINT,
+  sender VARCHAR(66),
+  entry_function VARCHAR(200),
+  transaction_timestamp TIMESTAMP,
+  inserted_at TIMESTAMP,
+
+  -- Market and state metadata.
+  market_id BIGINT,
+  symbol_bytes BYTEA,
+  symbol_emojis TEXT[],
+  bump_time TIMESTAMP, -- Note that bump and emit time are interchangeable.
+  market_nonce BIGINT,
+  trigger trigger_type,
+  market_address VARCHAR(66),
+
+  -- State event data.
+  clamm_virtual_reserves_base BIGINT,
+  clamm_virtual_reserves_quote BIGINT,
+  cpamm_real_reserves_base BIGINT,
+  cpamm_real_reserves_quote BIGINT,
+  lp_coin_supply NUMERIC,
+  cumulative_stats_base_volume NUMERIC,
+  cumulative_stats_quote_volume NUMERIC,
+  cumulative_stats_integrator_fees NUMERIC,
+  cumulative_stats_pool_fees_base NUMERIC,
+  cumulative_stats_pool_fees_quote NUMERIC,
+  cumulative_stats_n_swaps BIGINT,
+  cumulative_stats_n_chat_messages BIGINT,
+  instantaneous_stats_total_quote_locked BIGINT,
+  instantaneous_stats_total_value_locked NUMERIC,
+  instantaneous_stats_market_cap NUMERIC,
+  instantaneous_stats_fully_diluted_value NUMERIC,
+  last_swap_is_sell BOOLEAN,
+  last_swap_avg_execution_price_q64 NUMERIC,
+  last_swap_base_volume BIGINT,
+  last_swap_quote_volume BIGINT,
+  last_swap_nonce BIGINT,
+  last_swap_time TIMESTAMP,
+
+  -- Querying all post-bonding curve markets. i.e., markets with liquidity pools.
+  daily_tvl_per_lp_coin_growth_q64 NUMERIC,
+  in_bonding_curve BOOLEAN,
+  volume_in_1m_state_tracker NUMERIC,
+
+  daily_volume NUMERIC,
+
+  lp_coin_balance BIGINT
+)
+AS $$
+SELECT ms.*, ulp.lp_coin_balance
+FROM
+    market_state AS ms,
+    user_liquidity_pools AS ulp
+WHERE ms.market_id = ulp.market_id
+AND ulp.provider = $1
+AND lp_coin_balance <> 0
+$$ LANGUAGE SQL;
+
+ALTER TABLE market_latest_state_event RENAME COLUMN daily_tvl_per_lp_coin_growth TO daily_tvl_per_lp_coin_growth_q64;
+ALTER VIEW market_state RENAME COLUMN daily_tvl_per_lp_coin_growth TO daily_tvl_per_lp_coin_growth_q64;

--- a/rust/processor/src/db/postgres/migrations/2024-10-04-105346_fix_tvl_column_name/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-10-04-105346_fix_tvl_column_name/up.sql
@@ -1,0 +1,63 @@
+-- Your SQL goes here
+DROP FUNCTION user_pools(provider text);
+CREATE FUNCTION user_pools(provider text) RETURNS TABLE(
+  transaction_version BIGINT,
+  sender VARCHAR(66),
+  entry_function VARCHAR(200),
+  transaction_timestamp TIMESTAMP,
+  inserted_at TIMESTAMP,
+
+  -- Market and state metadata.
+  market_id BIGINT,
+  symbol_bytes BYTEA,
+  symbol_emojis TEXT[],
+  bump_time TIMESTAMP, -- Note that bump and emit time are interchangeable.
+  market_nonce BIGINT,
+  trigger trigger_type,
+  market_address VARCHAR(66),
+
+  -- State event data.
+  clamm_virtual_reserves_base BIGINT,
+  clamm_virtual_reserves_quote BIGINT,
+  cpamm_real_reserves_base BIGINT,
+  cpamm_real_reserves_quote BIGINT,
+  lp_coin_supply NUMERIC,
+  cumulative_stats_base_volume NUMERIC,
+  cumulative_stats_quote_volume NUMERIC,
+  cumulative_stats_integrator_fees NUMERIC,
+  cumulative_stats_pool_fees_base NUMERIC,
+  cumulative_stats_pool_fees_quote NUMERIC,
+  cumulative_stats_n_swaps BIGINT,
+  cumulative_stats_n_chat_messages BIGINT,
+  instantaneous_stats_total_quote_locked BIGINT,
+  instantaneous_stats_total_value_locked NUMERIC,
+  instantaneous_stats_market_cap NUMERIC,
+  instantaneous_stats_fully_diluted_value NUMERIC,
+  last_swap_is_sell BOOLEAN,
+  last_swap_avg_execution_price_q64 NUMERIC,
+  last_swap_base_volume BIGINT,
+  last_swap_quote_volume BIGINT,
+  last_swap_nonce BIGINT,
+  last_swap_time TIMESTAMP,
+
+  -- Querying all post-bonding curve markets. i.e., markets with liquidity pools.
+  daily_tvl_per_lp_coin_growth NUMERIC,
+  in_bonding_curve BOOLEAN,
+  volume_in_1m_state_tracker NUMERIC,
+
+  daily_volume NUMERIC,
+
+  lp_coin_balance BIGINT
+)
+AS $$
+SELECT ms.*, ulp.lp_coin_balance
+FROM
+    market_state AS ms,
+    user_liquidity_pools AS ulp
+WHERE ms.market_id = ulp.market_id
+AND ulp.provider = $1
+AND lp_coin_balance <> 0
+$$ LANGUAGE SQL;
+
+ALTER TABLE market_latest_state_event RENAME COLUMN daily_tvl_per_lp_coin_growth_q64 TO daily_tvl_per_lp_coin_growth;
+ALTER VIEW market_state RENAME COLUMN daily_tvl_per_lp_coin_growth_q64 TO daily_tvl_per_lp_coin_growth;

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -1058,7 +1058,7 @@ diesel::table! {
         last_swap_quote_volume -> Int8,
         last_swap_nonce -> Int8,
         last_swap_time -> Timestamp,
-        daily_tvl_per_lp_coin_growth_q64 -> Numeric,
+        daily_tvl_per_lp_coin_growth -> Numeric,
         in_bonding_curve -> Bool,
         volume_in_1m_state_tracker -> Numeric,
     }


### PR DESCRIPTION
This PR will rename the field `daily_tvl_per_lp_coin_growth_q64` to `daily_tvl_per_lp_coin_growth` as it is not a `q64` number but a normal one.