### PR TITLE
[ECO-2310] Rework price feed to show newly registered markets

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2024-10-20-152751_rework_price_feed/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-10-20-152751_rework_price_feed/down.sql
@@ -1,0 +1,38 @@
+-- This file should undo anything in `up.sql`
+CREATE OR REPLACE FUNCTION price_feed() RETURNS TABLE(
+  market_id BIGINT,
+  symbol_bytes BYTEA,
+  symbol_emojis TEXT[],
+  market_address VARCHAR(66),
+  open_price_q64 NUMERIC,
+  close_price_q64 NUMERIC
+)
+AS $$
+WITH markets AS (
+    SELECT market_id
+    FROM market_daily_volume
+    ORDER BY daily_volume DESC
+    LIMIT 25
+),
+swap24 AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    WHERE transaction_timestamp <= CURRENT_TIMESTAMP - interval '1 day'
+    ORDER BY
+        market_id,
+        transaction_timestamp DESC
+)
+SELECT
+    swap_close.market_id,
+    swap_close.symbol_bytes,
+    swap_close.symbol_emojis,
+    swap_close.market_address,
+    swap_open.avg_execution_price_q64 AS open_price_q64,
+    swap_close.last_swap_avg_execution_price_q64 AS close_price_q64
+FROM markets
+INNER JOIN market_latest_state_event AS swap_close ON markets.market_id = swap_close.market_id
+INNER JOIN swap24 AS swap_open ON markets.market_id = swap_open.market_id
+WHERE swap_close.transaction_timestamp > CURRENT_TIMESTAMP - interval '1 day'
+$$ LANGUAGE SQL;

--- a/rust/processor/src/db/postgres/migrations/2024-10-20-152751_rework_price_feed/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-10-20-152751_rework_price_feed/up.sql
@@ -1,0 +1,47 @@
+CREATE OR REPLACE FUNCTION price_feed() RETURNS TABLE(
+  market_id BIGINT,
+  symbol_bytes BYTEA,
+  symbol_emojis TEXT[],
+  market_address VARCHAR(66),
+  open_price_q64 NUMERIC,
+  close_price_q64 NUMERIC
+)
+AS $$
+WITH markets AS (
+    SELECT market_id
+    FROM market_daily_volume
+    ORDER BY daily_volume DESC
+    LIMIT 25
+),
+swap24 AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    WHERE transaction_timestamp <= CURRENT_TIMESTAMP - interval '1 day'
+    ORDER BY
+        market_id,
+        transaction_timestamp DESC
+),
+first_swap AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    ORDER BY
+        market_id,
+        transaction_timestamp ASC
+)
+SELECT
+    swap_close.market_id,
+    swap_close.symbol_bytes,
+    swap_close.symbol_emojis,
+    swap_close.market_address,
+    COALESCE(swap_open.avg_execution_price_q64, first_swap.avg_execution_price_q64) AS open_price_q64,
+    swap_close.last_swap_avg_execution_price_q64 AS close_price_q64
+FROM markets
+INNER JOIN market_latest_state_event AS swap_close ON markets.market_id = swap_close.market_id
+INNER JOIN first_swap ON markets.market_id = first_swap.market_id
+LEFT JOIN swap24 AS swap_open ON markets.market_id = swap_open.market_id
+WHERE swap_close.transaction_timestamp > CURRENT_TIMESTAMP - interval '1 day'
+$$ LANGUAGE SQL;


### PR DESCRIPTION
This PR reworks how the price feed is calculated in order to take into account markets that have been registered in the last 24 hours.