### PR TITLE
[ECO-2402] Parallelize processor image build, add `yamllint`, patch Dockerfile

### DIFF
--- a/.github/workflows/push-processor.yaml
+++ b/.github/workflows/push-processor.yaml
@@ -23,9 +23,14 @@ jobs:
         context: 'rust'
         file: 'rust/Dockerfile'
         labels: '${{ steps.metadata.outputs.labels }}'
-        platforms: '${{ vars.DOCKER_IMAGE_PLATFORMS }}'
+        platforms: '${{ matrix.platform }}'
         push: 'true'
         tags: '${{ steps.metadata.outputs.tags }}'
+    strategy:
+      fail-fast: 'true'
+      matrix:
+        platform: >-
+          ${{ split(vars.DOCKER_IMAGE_PLATFORMS, ',') }}
     timeout-minutes: 360
 name: 'Build processor Docker image and push to Docker Hub'
 'on':

--- a/.github/workflows/push-processor.yaml
+++ b/.github/workflows/push-processor.yaml
@@ -30,7 +30,10 @@ jobs:
       fail-fast: 'true'
       matrix:
         platform: >-
-          ${{ split(vars.DOCKER_IMAGE_PLATFORMS, ',') }}
+          ${{ fromJSON(format(
+          '["{}"]',
+          replace(vars.DOCKER_IMAGE_PLATFORMS, ',', '","')
+          )) }}
     timeout-minutes: 360
 name: 'Build processor Docker image and push to Docker Hub'
 'on':

--- a/.github/workflows/push-processor.yaml
+++ b/.github/workflows/push-processor.yaml
@@ -27,7 +27,6 @@ jobs:
         push: 'true'
         tags: '${{ steps.metadata.outputs.tags }}'
     strategy:
-      fail-fast: 'true'
       matrix:
         platform:
         - 'linux/amd64'

--- a/.github/workflows/push-processor.yaml
+++ b/.github/workflows/push-processor.yaml
@@ -29,11 +29,9 @@ jobs:
     strategy:
       fail-fast: 'true'
       matrix:
-        platform: >-
-          ${{ fromJSON(format(
-          '["{}"]',
-          replace(vars.DOCKER_IMAGE_PLATFORMS, ',', '","')
-          )) }}
+        platform:
+        - 'linux/amd64'
+        - 'linux/arm64'
     timeout-minutes: 360
 name: 'Build processor Docker image and push to Docker Hub'
 'on':

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
 -
   hooks:
   -
-    id: 'hadolint-docker'
     files: 'rust/Dockerfile'
+    id: 'hadolint-docker'
   repo: 'https://github.com/hadolint/hadolint'
   rev: 'v2.12.0'
 -
@@ -29,4 +29,14 @@ repos:
     id: 'clippy'
   repo: 'https://github.com/doublify/pre-commit-rust'
   rev: 'v1.0'
+-
+  hooks:
+  -
+    args:
+    - '--config-file'
+    - 'cfg/yamllint-config.yaml'
+    - '--strict'
+    id: 'yamllint'
+  repo: 'https://github.com/adrienverge/yamllint'
+  rev: 'v1.35.1'
 ...

--- a/cfg/yamllint-config.yaml
+++ b/cfg/yamllint-config.yaml
@@ -1,0 +1,49 @@
+---
+extends: 'default'
+# Most files to ignore are from upstream fork.
+ignore:
+- '*pnpm-lock.yaml'
+- '.github/actions/docker-setup/action.yaml'
+- '.github/actions/protobuf-compatibility-check/action.yaml'
+- '.github/actions/python-setup/action.yaml'
+- '.github/actions/rust-setup/action.yaml'
+- '.github/workflows/rustfmt.yaml'
+- 'python/docker-compose.yml'
+- 'rust/processor/parser.yaml'
+rules:
+  braces:
+    forbid: true
+  brackets:
+    forbid: true
+  comments:
+    ignore-shebangs: true
+    level: 'error'
+    min-spaces-from-content: 1
+    require-starting-space: true
+  comments-indentation:
+    level: 'error'
+  document-end: 'enable'
+  document-start:
+    level: 'error'
+  empty-lines:
+    max: 0
+    max-end: 1
+    max-start: 0
+  empty-values: 'enable'
+  float-values:
+    forbid-inf: false
+    forbid-nan: false
+    forbid-scientific-notation: true
+    require-numeral-before-decimal: true
+  indentation:
+    check-multi-line-strings: true
+    indent-sequences: false
+    spaces: 2
+  key-ordering: 'enable'
+  octal-values: 'enable'
+  quoted-strings:
+    quote-type: 'single'
+    required: true
+  truthy:
+    level: 'error'
+...

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -62,7 +62,8 @@ RUN cargo build --bin processor --package processor --release \
     && cargo install diesel_cli --no-default-features --features postgres \
     && mkdir /data \
     && chown postgres:postgres /data \
-    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+    && locale-gen \
     && su - postgres -c "/usr/lib/postgresql/16/bin/initdb /data \
         --locale-provider=libc \
         --locale=en_US.UTF-8 \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -56,12 +56,12 @@ RUN cargo build \
     && cp target/release/processor /usr/local/bin \
     && apt-get update && apt-get install -y --no-install-recommends \
         postgresql-common=248* \
-    && rm -rf /var/lib/apt/lists/* \
+        && rm -rf /var/lib/apt/lists/* \
     && yes | /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh \
     && apt-get update && apt-get install -y --no-install-recommends \
         postgresql-16=16.4* \
         postgresql-client-16=16.4* \
-    && rm -rf /var/lib/apt/lists/* \
+        && rm -rf /var/lib/apt/lists/* \
     && cargo install diesel_cli --no-default-features --features postgres \
     && mkdir /data \
     && chown postgres:postgres /data \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -48,27 +48,39 @@ RUN cargo chef cook \
     --package processor \
     --release
 COPY . .
-# hadolint ignore=DL3003,DL4006
 RUN cargo build \
     --bin processor \
     --package processor \
     --release \
     && cp target/release/processor /usr/local/bin \
     && apt-get update && apt-get install -y --no-install-recommends \
-       postgresql-common=248* \
+        postgresql-common=248* \
     && rm -rf /var/lib/apt/lists/* \
     && yes | /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh \
     && apt-get update && apt-get install -y --no-install-recommends \
-       postgresql-16=16.4-1.pgdg120* \
-       postgresql-client-16=16.4-1.pgdg120* \
+        postgresql-16=16.4* \
+        postgresql-client-16=16.4* \
     && rm -rf /var/lib/apt/lists/* \
     && cargo install diesel_cli --no-default-features --features postgres \
-    && mkdir /data && chown postgres:postgres /data \
-    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
-    && su - postgres -c "/usr/lib/postgresql/16/bin/initdb /data --locale-provider=libc --locale=en_US.UTF-8 && /usr/lib/postgresql/16/bin/pg_ctl -D /data -l logfile start" \
-    && su - postgres -c "/usr/lib/postgresql/16/bin/psql -c \"CREATE ROLE emojicoin ENCRYPTED PASSWORD 'emojicoin' SUPERUSER CREATEDB CREATEROLE INHERIT LOGIN;"\" \
-    && cd processor/src/db/postgres && sleep 4 && diesel --database-url postgres://emojicoin:emojicoin@localhost/emojicoin setup \
-    && pg_dumpall -d postgres://emojicoin:emojicoin@localhost/emojicoin > /db.sql
+    && mkdir /data \
+    && chown postgres:postgres /data \
+    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+    && locale-gen \
+    && su - postgres -c "/usr/lib/postgresql/16/bin/initdb /data \
+        --locale-provider=libc \
+        --locale=en_US.UTF-8 \
+        && /usr/lib/postgresql/16/bin/pg_ctl -D /data -l logfile start" \
+    && su - postgres -c "/usr/lib/postgresql/16/bin/psql -c \
+        \"CREATE ROLE emojicoin \
+        ENCRYPTED PASSWORD 'emojicoin' \
+        SUPERUSER CREATEDB CREATEROLE \
+        INHERIT LOGIN;\"" \
+    && cd processor/src/db/postgres \
+    && sleep 4 \
+    && diesel --database-url \
+        postgres://emojicoin:emojicoin@localhost/emojicoin setup \
+    && pg_dumpall -d \
+        postgres://emojicoin:emojicoin@localhost/emojicoin > /db.sql
 
 # Install runtime dependencies, copy over binaries.
 FROM debian:bookworm-slim AS runtime

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -40,7 +40,7 @@ RUN cargo build \
     --release \
     && cp target/release/indexer-metrics /usr/local/bin
 
-# Cache crate dependencies, then compile processor binary.
+# Cache crate dependencies, compile processor binary, pre-load migrations.
 FROM base AS processor-builder
 COPY --from=processor-planner app/recipe.json recipe.json
 RUN cargo chef cook \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -48,25 +48,21 @@ RUN cargo chef cook \
     --package processor \
     --release
 COPY . .
-# hadolint ignore=DL4006
-RUN cargo build \
-    --bin processor \
-    --package processor \
-    --release \
+# hadolint ignore=DL3003,DL4006
+RUN cargo build --bin processor --package processor --release \
     && cp target/release/processor /usr/local/bin \
     && apt-get update && apt-get install -y --no-install-recommends \
         postgresql-common=248* \
         && rm -rf /var/lib/apt/lists/* \
     && yes | /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh \
     && apt-get update && apt-get install -y --no-install-recommends \
-        postgresql-16=16.4* \
-        postgresql-client-16=16.4* \
+        postgresql-16=16* \
+        postgresql-client-16=16* \
         && rm -rf /var/lib/apt/lists/* \
     && cargo install diesel_cli --no-default-features --features postgres \
     && mkdir /data \
     && chown postgres:postgres /data \
-    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
-    && locale-gen \
+    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
     && su - postgres -c "/usr/lib/postgresql/16/bin/initdb /data \
         --locale-provider=libc \
         --locale=en_US.UTF-8 \
@@ -75,9 +71,9 @@ RUN cargo build \
         \"CREATE ROLE emojicoin \
         ENCRYPTED PASSWORD 'emojicoin' \
         SUPERUSER CREATEDB CREATEROLE \
-        INHERIT LOGIN;\""
-WORKDIR /app/processor/src/db/postgres
-RUN sleep 4 \
+        INHERIT LOGIN;"\" \
+    && cd processor/src/db/postgres \
+    && sleep 5 \
     && diesel --database-url \
         postgres://emojicoin:emojicoin@localhost/emojicoin setup \
     && pg_dumpall -d \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -48,6 +48,7 @@ RUN cargo chef cook \
     --package processor \
     --release
 COPY . .
+# hadolint ignore=DL4006
 RUN cargo build \
     --bin processor \
     --package processor \
@@ -74,9 +75,9 @@ RUN cargo build \
         \"CREATE ROLE emojicoin \
         ENCRYPTED PASSWORD 'emojicoin' \
         SUPERUSER CREATEDB CREATEROLE \
-        INHERIT LOGIN;\"" \
-    && cd processor/src/db/postgres \
-    && sleep 4 \
+        INHERIT LOGIN;\""
+WORKDIR /app/processor/src/db/postgres
+RUN sleep 4 \
     && diesel --database-url \
         postgres://emojicoin:emojicoin@localhost/emojicoin setup \
     && pg_dumpall -d \


### PR DESCRIPTION
# Changes

1. Use a matrix build strategy so that processor dockerfiles build in parallel across different platforms
2. Add `yamllint` support to `pre-commit`
3. Relax restrictions on `postgresql` and `postgresql-client` versions
4. Line break compound Docker commands for readability
5. Replace escape of Docker lint warning about directory change by using `WORKDIR` command

# Testing

Tag `emojicoin-processor-v0.9.2`