### PR TITLE
[ECO-2498] Drop `price_feed` function and replace it with `price_feed` view that returns market data as well

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2024-11-26-050428_add_market_data_to_price_feed/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-11-26-050428_add_market_data_to_price_feed/down.sql
@@ -1,5 +1,5 @@
 -- This file should undo anything in `up.sql`
-DROP VIEW price_feed_with_market_state;
+DROP VIEW price_feed;
 
 CREATE OR REPLACE FUNCTION price_feed() RETURNS TABLE(
   market_id BIGINT,

--- a/rust/processor/src/db/postgres/migrations/2024-11-26-050428_add_market_data_to_price_feed/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-11-26-050428_add_market_data_to_price_feed/down.sql
@@ -1,0 +1,40 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW price_feed_with_market_state;
+
+CREATE OR REPLACE FUNCTION price_feed() RETURNS TABLE(
+  market_id BIGINT,
+  symbol_bytes BYTEA,
+  symbol_emojis TEXT[],
+  market_address VARCHAR(66),
+  open_price_q64 NUMERIC,
+  close_price_q64 NUMERIC
+)
+AS $$
+WITH markets AS (
+    SELECT market_id
+    FROM market_daily_volume
+    ORDER BY daily_volume DESC
+    LIMIT 25
+),
+swap24 AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    WHERE transaction_timestamp <= CURRENT_TIMESTAMP - interval '1 day'
+    ORDER BY
+        market_id,
+        transaction_timestamp DESC
+)
+SELECT
+    swap_close.market_id,
+    swap_close.symbol_bytes,
+    swap_close.symbol_emojis,
+    swap_close.market_address,
+    swap_open.avg_execution_price_q64 AS open_price_q64,
+    swap_close.last_swap_avg_execution_price_q64 AS close_price_q64
+FROM markets
+INNER JOIN market_latest_state_event AS swap_close ON markets.market_id = swap_close.market_id
+INNER JOIN swap24 AS swap_open ON markets.market_id = swap_open.market_id
+WHERE swap_close.transaction_timestamp > CURRENT_TIMESTAMP - interval '1 day'
+$$ LANGUAGE SQL;

--- a/rust/processor/src/db/postgres/migrations/2024-11-26-050428_add_market_data_to_price_feed/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-11-26-050428_add_market_data_to_price_feed/down.sql
@@ -1,5 +1,6 @@
 -- This file should undo anything in `up.sql`
 DROP VIEW price_feed;
+ALTER INDEX price_feed_idx RENAME TO price_feed;
 
 CREATE OR REPLACE FUNCTION price_feed() RETURNS TABLE(
   market_id BIGINT,

--- a/rust/processor/src/db/postgres/migrations/2024-11-26-050428_add_market_data_to_price_feed/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-11-26-050428_add_market_data_to_price_feed/down.sql
@@ -25,16 +25,26 @@ swap24 AS (
     ORDER BY
         market_id,
         transaction_timestamp DESC
+),
+first_swap AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    ORDER BY
+        market_id,
+        transaction_timestamp ASC
 )
 SELECT
     swap_close.market_id,
     swap_close.symbol_bytes,
     swap_close.symbol_emojis,
     swap_close.market_address,
-    swap_open.avg_execution_price_q64 AS open_price_q64,
+    COALESCE(swap_open.avg_execution_price_q64, first_swap.avg_execution_price_q64) AS open_price_q64,
     swap_close.last_swap_avg_execution_price_q64 AS close_price_q64
 FROM markets
 INNER JOIN market_latest_state_event AS swap_close ON markets.market_id = swap_close.market_id
-INNER JOIN swap24 AS swap_open ON markets.market_id = swap_open.market_id
+INNER JOIN first_swap ON markets.market_id = first_swap.market_id
+LEFT JOIN swap24 AS swap_open ON markets.market_id = swap_open.market_id
 WHERE swap_close.transaction_timestamp > CURRENT_TIMESTAMP - interval '1 day'
 $$ LANGUAGE SQL;

--- a/rust/processor/src/db/postgres/migrations/2024-11-26-050428_add_market_data_to_price_feed/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-11-26-050428_add_market_data_to_price_feed/up.sql
@@ -1,5 +1,6 @@
 -- Your SQL goes here
 DROP FUNCTION price_feed;
+ALTER INDEX price_feed RENAME TO price_feed_idx;
 
 CREATE OR REPLACE VIEW price_feed AS
 WITH markets AS (
@@ -16,12 +17,22 @@ swap24 AS (
     ORDER BY
         market_id,
         transaction_timestamp DESC
+),
+first_swap AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    ORDER BY
+        market_id,
+        transaction_timestamp ASC
 )
 SELECT 
     latest_swap.*,
-    swap_open.avg_execution_price_q64 AS open_price_q64,
+    COALESCE(swap_open.avg_execution_price_q64, first_swap.avg_execution_price_q64) AS open_price_q64,
     latest_swap.last_swap_avg_execution_price_q64 AS close_price_q64
 FROM markets
 INNER JOIN market_state AS latest_swap ON markets.market_id = latest_swap.market_id
-INNER JOIN swap24 AS swap_open ON markets.market_id = swap_open.market_id
+INNER JOIN first_swap ON markets.market_id = first_swap.market_id
+LEFT JOIN swap24 AS swap_open ON markets.market_id = swap_open.market_id
 WHERE latest_swap.transaction_timestamp > CURRENT_TIMESTAMP - interval '1 day';

--- a/rust/processor/src/db/postgres/migrations/2024-11-26-050428_add_market_data_to_price_feed/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-11-26-050428_add_market_data_to_price_feed/up.sql
@@ -1,0 +1,27 @@
+-- Your SQL goes here
+DROP FUNCTION price_feed;
+
+CREATE OR REPLACE VIEW price_feed AS
+WITH markets AS (
+    SELECT market_id
+    FROM market_state
+    ORDER BY daily_volume DESC
+),
+swap24 AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    WHERE transaction_timestamp <= CURRENT_TIMESTAMP - interval '1 day'
+    ORDER BY
+        market_id,
+        transaction_timestamp DESC
+)
+SELECT 
+    latest_swap.*,
+    swap_open.avg_execution_price_q64 AS open_price_q64,
+    latest_swap.last_swap_avg_execution_price_q64 AS close_price_q64
+FROM markets
+INNER JOIN market_state AS latest_swap ON markets.market_id = latest_swap.market_id
+INNER JOIN swap24 AS swap_open ON markets.market_id = swap_open.market_id
+WHERE latest_swap.transaction_timestamp > CURRENT_TIMESTAMP - interval '1 day';


### PR DESCRIPTION
The `price_feed` function doesn't return data, and it's easier for us to make it a view that returns all the `market_data` columns as well.

 - [x] Drop the function
 - [x] Add it as a view
 - [x] Test the most performant query
 - [x] Rename the `price_feed` index to `price_feed_idx`. Postgres doesn't care if an index and a function share the same name but a view and an index can't.
