### PR TITLE
Dexscreener Emojicoin Support

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     utils::util::{
         deserialize_from_string, hex_to_raw_bytes, serialize_to_string, standardize_address,
+        deserialize_from_option_string, serialize_to_option_string,
         AggregatorSnapshot,
     },
 };
@@ -204,6 +205,9 @@ pub struct LastSwap {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SwapEvent {
+    #[serde(deserialize_with = "deserialize_from_option_string")]
+    #[serde(serialize_with = "serialize_to_option_string")]
+    pub event_index: Option<i64>,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
     pub market_id: i64,
@@ -383,6 +387,9 @@ pub struct GlobalStateEvent {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LiquidityEvent {
+    #[serde(deserialize_with = "deserialize_from_option_string")]
+    #[serde(serialize_with = "serialize_to_option_string")]
+    pub event_index: Option<i64>,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
     pub market_id: i64,
@@ -435,7 +442,7 @@ impl From<StateEvent> for EventWithMarket {
 }
 
 impl EventWithMarket {
-    pub fn from_event_type(event_type: &str, data: &str, txn_version: i64) -> Result<Option<Self>> {
+    pub fn from_event_type(event_type: &str, data: &str, txn_version: i64, sequence_number: i64) -> Result<Option<Self>> {
         match EmojicoinTypeTag::from_type_str(event_type) {
             Some(EmojicoinTypeTag::PeriodicState) => {
                 serde_json::from_str(data).map(|inner| Some(Self::PeriodicState(inner)))
@@ -444,7 +451,10 @@ impl EventWithMarket {
                 serde_json::from_str(data).map(|inner| Some(Self::State(inner)))
             },
             Some(EmojicoinTypeTag::Swap) => {
-                serde_json::from_str(data).map(|inner| Some(Self::Swap(inner)))
+                serde_json::from_str(data).map(|mut inner: SwapEvent| {
+                    inner.event_index = Some(sequence_number);
+                    Some(Self::Swap(inner))
+                })
             },
             Some(EmojicoinTypeTag::Chat) => {
                 serde_json::from_str(data).map(|inner| Some(Self::Chat(inner)))
@@ -453,7 +463,10 @@ impl EventWithMarket {
                 serde_json::from_str(data).map(|inner| Some(Self::MarketRegistration(inner)))
             },
             Some(EmojicoinTypeTag::Liquidity) => {
-                serde_json::from_str(data).map(|inner| Some(Self::Liquidity(inner)))
+                serde_json::from_str(data).map(|mut inner: LiquidityEvent| {
+                    inner.event_index = Some(sequence_number);
+                    Some(Self::Liquidity(inner))
+                })
             },
             _ => Ok(None),
         }
@@ -493,6 +506,7 @@ pub enum BumpEvent {
 // A subset of the transaction info that comes in from the GRPC stream.
 #[derive(Debug, Clone)]
 pub struct TxnInfo {
+    pub block_number: i64,
     pub version: i64,
     pub sender: String,
     pub entry_function: Option<String>,

--- a/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -457,7 +457,7 @@ impl EventWithMarket {
             },
             Some(EmojicoinTypeTag::Swap) => {
                 let mut json_data = serde_json::Value::from_str(data)?;
-                json_data["event_index"] = serde_json::Value::from(sequence_number);
+                json_data["event_index"] = serde_json::Value::from(sequence_number.to_string());
                 serde_json::from_value(json_data).map(|inner: SwapEvent| Some(Self::Swap(inner)))
             },
             Some(EmojicoinTypeTag::Chat) => {
@@ -468,7 +468,7 @@ impl EventWithMarket {
             },
             Some(EmojicoinTypeTag::Liquidity) => {
                 let mut json_data = serde_json::Value::from_str(data)?;
-                json_data["event_index"] = serde_json::Value::from(sequence_number);
+                json_data["event_index"] = serde_json::Value::from(sequence_number.to_string());
                 serde_json::from_value(json_data)
                     .map(|inner: LiquidityEvent| Some(Self::Liquidity(inner)))
             },

--- a/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -6,7 +6,6 @@ use crate::{
     },
     utils::util::{
         deserialize_from_string, hex_to_raw_bytes, serialize_to_string, standardize_address,
-        deserialize_from_option_string, serialize_to_option_string,
         AggregatorSnapshot,
     },
 };
@@ -14,6 +13,7 @@ use anyhow::{Context, Result};
 use aptos_protos::transaction::v1::WriteResource;
 use bigdecimal::BigDecimal;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::str::FromStr;
 
 pub fn serialize_bytes_to_hex_string<S>(element: &Vec<u8>, s: S) -> Result<S::Ok, S::Error>
 where
@@ -205,9 +205,9 @@ pub struct LastSwap {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SwapEvent {
-    #[serde(deserialize_with = "deserialize_from_option_string")]
-    #[serde(serialize_with = "serialize_to_option_string")]
-    pub event_index: Option<i64>,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub event_index: i64,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
     pub market_id: i64,
@@ -387,9 +387,9 @@ pub struct GlobalStateEvent {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LiquidityEvent {
-    #[serde(deserialize_with = "deserialize_from_option_string")]
-    #[serde(serialize_with = "serialize_to_option_string")]
-    pub event_index: Option<i64>,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub event_index: i64,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
     pub market_id: i64,
@@ -442,7 +442,12 @@ impl From<StateEvent> for EventWithMarket {
 }
 
 impl EventWithMarket {
-    pub fn from_event_type(event_type: &str, data: &str, txn_version: i64, sequence_number: i64) -> Result<Option<Self>> {
+    pub fn from_event_type(
+        event_type: &str,
+        data: &str,
+        txn_version: i64,
+        sequence_number: i64,
+    ) -> Result<Option<Self>> {
         match EmojicoinTypeTag::from_type_str(event_type) {
             Some(EmojicoinTypeTag::PeriodicState) => {
                 serde_json::from_str(data).map(|inner| Some(Self::PeriodicState(inner)))
@@ -451,10 +456,9 @@ impl EventWithMarket {
                 serde_json::from_str(data).map(|inner| Some(Self::State(inner)))
             },
             Some(EmojicoinTypeTag::Swap) => {
-                serde_json::from_str(data).map(|mut inner: SwapEvent| {
-                    inner.event_index = Some(sequence_number);
-                    Some(Self::Swap(inner))
-                })
+                let mut json_data = serde_json::Value::from_str(data)?;
+                json_data["event_index"] = serde_json::Value::from(sequence_number);
+                serde_json::from_value(json_data).map(|inner: SwapEvent| Some(Self::Swap(inner)))
             },
             Some(EmojicoinTypeTag::Chat) => {
                 serde_json::from_str(data).map(|inner| Some(Self::Chat(inner)))
@@ -463,10 +467,10 @@ impl EventWithMarket {
                 serde_json::from_str(data).map(|inner| Some(Self::MarketRegistration(inner)))
             },
             Some(EmojicoinTypeTag::Liquidity) => {
-                serde_json::from_str(data).map(|mut inner: LiquidityEvent| {
-                    inner.event_index = Some(sequence_number);
-                    Some(Self::Liquidity(inner))
-                })
+                let mut json_data = serde_json::Value::from_str(data)?;
+                json_data["event_index"] = serde_json::Value::from(sequence_number);
+                serde_json::from_value(json_data)
+                    .map(|inner: LiquidityEvent| Some(Self::Liquidity(inner)))
             },
             _ => Ok(None),
         }

--- a/rust/processor/src/db/common/models/emojicoin_models/models/liquidity_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/liquidity_event.rs
@@ -103,7 +103,7 @@ impl LiquidityEventModel {
             // Transaction metadata.
             block_number: txn_info.block_number,
             transaction_version: txn_info.version,
-            event_index: event_index.expect("Event index should be set before insertion."),
+            event_index,
             sender: txn_info.sender.clone(),
             entry_function: txn_info.entry_function.clone(),
             transaction_timestamp: txn_info.timestamp,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/liquidity_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/liquidity_event.rs
@@ -16,7 +16,9 @@ use serde::{Deserialize, Serialize};
 #[diesel(table_name = liquidity_events)]
 pub struct LiquidityEventModel {
     // Transaction metadata.
+    pub block_number: i64,
     pub transaction_version: i64,
+    pub event_index: i64,
     pub sender: String,
     pub entry_function: Option<String>,
     pub transaction_timestamp: chrono::NaiveDateTime,
@@ -93,12 +95,15 @@ impl LiquidityEventModel {
             liquidity_provided,
             base_donation_claim_amount,
             quote_donation_claim_amount,
+            event_index,
             ..
         } = liquidity_event;
 
         LiquidityEventModel {
             // Transaction metadata.
+            block_number: txn_info.block_number,
             transaction_version: txn_info.version,
+            event_index: event_index.expect("Event index should be set before insertion."),
             sender: txn_info.sender.clone(),
             entry_function: txn_info.entry_function.clone(),
             transaction_timestamp: txn_info.timestamp,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/swap_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/swap_event.rs
@@ -16,7 +16,9 @@ use serde::{Deserialize, Serialize};
 #[diesel(table_name = swap_events)]
 pub struct SwapEventModel {
     // Transaction metadata.
+    pub block_number: i64,
     pub transaction_version: i64,
+    pub event_index: i64,
     pub sender: String,
     pub entry_function: Option<String>,
     pub transaction_timestamp: chrono::NaiveDateTime,
@@ -84,6 +86,7 @@ impl SwapEventModel {
         } = state_event;
 
         let SwapEvent {
+            event_index,
             market_id,
             market_nonce,
             swapper,
@@ -107,7 +110,9 @@ impl SwapEventModel {
 
         SwapEventModel {
             // Transaction metadata.
+            block_number: txn_info.block_number,
             transaction_version: txn_info.version,
+            event_index: event_index.expect("Event index should be set before insertion."),
             sender: txn_info.sender.clone(),
             entry_function: txn_info.entry_function.clone(),
             transaction_timestamp: txn_info.timestamp,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/swap_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/swap_event.rs
@@ -112,7 +112,7 @@ impl SwapEventModel {
             // Transaction metadata.
             block_number: txn_info.block_number,
             transaction_version: txn_info.version,
-            event_index: event_index.expect("Event index should be set before insertion."),
+            event_index,
             sender: txn_info.sender.clone(),
             entry_function: txn_info.entry_function.clone(),
             transaction_timestamp: txn_info.timestamp,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/user_liquidity_pools.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/user_liquidity_pools.rs
@@ -12,6 +12,11 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
+
+static ADDRESSES_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new("^0x0*1::coin::CoinStore<(0x[^:]*)::coin_factory::EmojicoinLP>$").unwrap()
+});
+
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(provider, market_nonce))]
 #[diesel(table_name = user_liquidity_pools)]
@@ -45,9 +50,7 @@ impl UserLiquidityPoolsModel {
         evt: LiquidityEventModel,
         market_address: &str,
     ) -> Self {
-        static ADDRESSES_REGEX: Lazy<Regex> = Lazy::new(|| {
-            Regex::new("^0x0*1::coin::CoinStore<(0x[^:]*)::coin_factory::EmojicoinLP>$").unwrap()
-        });
+
         txn.info
             .as_ref()
             .expect("Transaction info should exist.")

--- a/rust/processor/src/db/common/models/emojicoin_models/models/user_liquidity_pools.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/user_liquidity_pools.rs
@@ -12,7 +12,6 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-
 static ADDRESSES_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new("^0x0*1::coin::CoinStore<(0x[^:]*)::coin_factory::EmojicoinLP>$").unwrap()
 });
@@ -50,7 +49,6 @@ impl UserLiquidityPoolsModel {
         evt: LiquidityEventModel,
         market_address: &str,
     ) -> Self {
-
         txn.info
             .as_ref()
             .expect("Transaction info should exist.")

--- a/rust/processor/src/db/postgres/migrations/2024-12-03-050428_add_block_number_and_event_index/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-12-03-050428_add_block_number_and_event_index/down.sql
@@ -1,0 +1,11 @@
+-- This file should undo anything in `up.sql`
+
+DROP INDEX IF EXISTS se_block_num;
+ALTER TABLE swap_events
+        DROP COLUMN block_number,
+        DROP COLUMN event_index;
+
+DROP INDEX IF EXISTS le_block_num;
+ALTER TABLE liquidity_events
+        DROP COLUMN block_number,
+        DROP COLUMN event_index;

--- a/rust/processor/src/db/postgres/migrations/2024-12-03-050428_add_block_number_and_event_index/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-12-03-050428_add_block_number_and_event_index/up.sql
@@ -1,0 +1,10 @@
+-- Your SQL goes here
+ALTER TABLE swap_events
+        ADD COLUMN block_number BIGINT NOT NULL,
+        ADD COLUMN event_index BIGINT NOT NULL;
+CREATE INDEX se_block_num ON swap_events (block_number);
+
+ALTER TABLE liquidity_events
+        ADD COLUMN block_number BIGINT NOT NULL,
+        ADD COLUMN event_index BIGINT NOT NULL;
+CREATE INDEX le_block_num ON liquidity_events (block_number);

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -957,10 +957,7 @@ diesel::table! {
     use super::sql_types::TriggerType;
 
     liquidity_events (market_id, market_nonce) {
-        block_number -> Int8,
         transaction_version -> Int8,
-        event_index -> Int8,
-
         #[max_length = 66]
         sender -> Varchar,
         #[max_length = 200]
@@ -1005,6 +1002,8 @@ diesel::table! {
         last_swap_quote_volume -> Int8,
         last_swap_nonce -> Int8,
         last_swap_time -> Timestamp,
+        block_number -> Int8,
+        event_index -> Int8,
     }
 }
 
@@ -1268,10 +1267,7 @@ diesel::table! {
     use super::sql_types::TriggerType;
 
     swap_events (market_id, market_nonce) {
-        block_number -> Int8,
         transaction_version -> Int8,
-        event_index -> Int8,
-
         #[max_length = 66]
         sender -> Varchar,
         #[max_length = 200]
@@ -1319,6 +1315,8 @@ diesel::table! {
         instantaneous_stats_fully_diluted_value -> Numeric,
         balance_as_fraction_of_circulating_supply_before_q64 -> Numeric,
         balance_as_fraction_of_circulating_supply_after_q64 -> Numeric,
+        block_number -> Int8,
+        event_index -> Int8,
     }
 }
 

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -957,7 +957,10 @@ diesel::table! {
     use super::sql_types::TriggerType;
 
     liquidity_events (market_id, market_nonce) {
+        block_number -> Int8,
         transaction_version -> Int8,
+        event_index -> Int8,
+
         #[max_length = 66]
         sender -> Varchar,
         #[max_length = 200]
@@ -1265,7 +1268,10 @@ diesel::table! {
     use super::sql_types::TriggerType;
 
     swap_events (market_id, market_nonce) {
+        block_number -> Int8,
         transaction_version -> Int8,
+        event_index -> Int8,
+
         #[max_length = 66]
         sender -> Varchar,
         #[max_length = 200]

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -273,7 +273,12 @@ impl ProcessorTrait for EmojicoinProcessor {
                     let type_str = event.type_str.as_str();
                     let data = event.data.as_str();
 
-                    match EventWithMarket::from_event_type(type_str, data, txn_version, event.sequence_number as i64)? {
+                    match EventWithMarket::from_event_type(
+                        type_str,
+                        data,
+                        txn_version,
+                        event.sequence_number as i64,
+                    )? {
                         Some(evt) => {
                             market_events.push(evt.clone());
                             if let Some(one_min_pse) =

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -238,6 +238,7 @@ impl ProcessorTrait for EmojicoinProcessor {
         let mut user_pools_db: AHashMap<(String, i64), UserLiquidityPoolsModel> = AHashMap::new();
         for txn in &transactions {
             let txn_version = txn.version as i64;
+            let block_number = txn.block_height as i64;
             let txn_data = match txn.txn_data.as_ref() {
                 Some(data) => data,
                 None => {
@@ -259,6 +260,7 @@ impl ProcessorTrait for EmojicoinProcessor {
                     .expect("User request info is not present in the user transaction.");
                 let entry_function = get_entry_function_from_user_request(user_request);
                 let txn_info = TxnInfo {
+                    block_number,
                     version: txn_version,
                     sender: standardize_address(user_request.sender.as_ref()),
                     entry_function,
@@ -271,7 +273,7 @@ impl ProcessorTrait for EmojicoinProcessor {
                     let type_str = event.type_str.as_str();
                     let data = event.data.as_str();
 
-                    match EventWithMarket::from_event_type(type_str, data, txn_version)? {
+                    match EventWithMarket::from_event_type(type_str, data, txn_version, event.sequence_number as i64)? {
                         Some(evt) => {
                             market_events.push(evt.clone());
                             if let Some(one_min_pse) =

--- a/rust/processor/src/utils/util.rs
+++ b/rust/processor/src/utils/util.rs
@@ -449,6 +449,18 @@ where
     s.serialize_str(&element.to_string())
 }
 
+/// Serialize to Option<string> from type Option<T>
+pub fn serialize_to_option_string<S, T>(element: &Option<T>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: std::fmt::Display,
+{
+    match element {
+        Some(e) => s.serialize_str(&e.to_string()),
+        None => s.serialize_none(),
+    }
+}
+
 /// Deserialize from string to type T
 pub fn deserialize_from_string<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
@@ -460,6 +472,22 @@ where
 
     let s = <String>::deserialize(deserializer)?;
     s.parse::<T>().map_err(D::Error::custom)
+}
+
+/// Deserialize from string to type Option<T>
+pub fn deserialize_from_option_string<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr,
+    <T as FromStr>::Err: std::fmt::Display,
+{
+    use serde::de::Error;
+
+    let s = <Option<String>>::deserialize(deserializer)?;
+    match s {
+        Some(s) => s.parse::<T>().map(Some).map_err(D::Error::custom),
+        None => Ok(None),
+    }
 }
 
 /// Convert the protobuf Timestamp to epcoh time in seconds.

--- a/rust/processor/src/utils/util.rs
+++ b/rust/processor/src/utils/util.rs
@@ -449,18 +449,6 @@ where
     s.serialize_str(&element.to_string())
 }
 
-/// Serialize to Option<string> from type Option<T>
-pub fn serialize_to_option_string<S, T>(element: &Option<T>, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    T: std::fmt::Display,
-{
-    match element {
-        Some(e) => s.serialize_str(&e.to_string()),
-        None => s.serialize_none(),
-    }
-}
-
 /// Deserialize from string to type T
 pub fn deserialize_from_string<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
@@ -472,22 +460,6 @@ where
 
     let s = <String>::deserialize(deserializer)?;
     s.parse::<T>().map_err(D::Error::custom)
-}
-
-/// Deserialize from string to type Option<T>
-pub fn deserialize_from_option_string<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
-where
-    D: Deserializer<'de>,
-    T: FromStr,
-    <T as FromStr>::Err: std::fmt::Display,
-{
-    use serde::de::Error;
-
-    let s = <Option<String>>::deserialize(deserializer)?;
-    match s {
-        Some(s) => s.parse::<T>().map(Some).map_err(D::Error::custom),
-        None => Ok(None),
-    }
 }
 
 /// Convert the protobuf Timestamp to epcoh time in seconds.


### PR DESCRIPTION
 Adds `block_number` and the `event_index` to liquidity and swap events. 

This can help make it easier to debug, and models the ‘correct’ way to represent blocks/transactions/events on chain to external parties like dexscreener. I was initially trying to avoid this by being a bit hacky, but I do worry about setting weird precedents when we start with dexscreener could end up with weird behavior when other projects eventually integrate too.

This is explicitly not backwards compatible.