### PR TITLE
[ECO-2572] Add daily base volume

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/models/market_1m_periods_in_last_day.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/market_1m_periods_in_last_day.rs
@@ -22,6 +22,7 @@ pub struct MarketOneMinutePeriodsInLastDayModel {
     pub nonce: i64,
     pub transaction_version: i64,
     pub volume: BigDecimal,
+    pub base_volume: BigDecimal,
     pub start_time: NaiveDateTime,
 }
 
@@ -31,7 +32,8 @@ impl From<RecentOneMinutePeriodicStateEvent> for MarketOneMinutePeriodsInLastDay
             market_id: event.market_id,
             nonce: event.market_nonce,
             transaction_version: event.transaction_version,
-            volume: event.period_volume,
+            volume: event.period_quote_volume,
+            base_volume: event.period_base_volume,
             start_time: event.start_time,
         }
     }

--- a/rust/processor/src/db/common/models/emojicoin_models/models/market_24h_rolling_volume.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/market_24h_rolling_volume.rs
@@ -12,7 +12,8 @@ pub struct RecentOneMinutePeriodicStateEvent {
     pub market_id: i64,
     pub market_nonce: i64,
     pub transaction_version: i64,
-    pub period_volume: BigDecimal,
+    pub period_quote_volume: BigDecimal,
+    pub period_base_volume: BigDecimal,
     pub start_time: NaiveDateTime,
 }
 
@@ -34,7 +35,8 @@ impl RecentOneMinutePeriodicStateEvent {
                         market_id: pse.market_metadata.market_id,
                         market_nonce: pse.periodic_state_metadata.emit_market_nonce,
                         transaction_version: version,
-                        period_volume: pse.volume_quote.clone(),
+                        period_quote_volume: pse.volume_quote.clone(),
+                        period_base_volume: pse.volume_base.clone(),
                         start_time,
                     })
                 } else {

--- a/rust/processor/src/db/common/models/emojicoin_models/models/market_latest_state_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/market_latest_state_event.rs
@@ -60,6 +60,7 @@ pub struct MarketLatestStateEventModel {
     pub daily_tvl_per_lp_coin_growth: BigDecimal,
     pub in_bonding_curve: bool,
     pub volume_in_1m_state_tracker: BigDecimal,
+    pub base_volume_in_1m_state_tracker: BigDecimal,
 }
 
 impl MarketLatestStateEventModel {
@@ -134,6 +135,7 @@ impl MarketLatestStateEventModel {
             daily_tvl_per_lp_coin_growth: calculate_tvl_growth(tracker_1d),
             in_bonding_curve: tracker_1m.ends_in_bonding_curve,
             volume_in_1m_state_tracker: tracker_1m.volume_quote,
+            base_volume_in_1m_state_tracker: tracker_1m.volume_base,
         }
     }
 }

--- a/rust/processor/src/db/postgres/migrations/2024-12-18-143643_add_daily_base_volume/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-12-18-143643_add_daily_base_volume/down.sql
@@ -1,0 +1,95 @@
+-- This file should undo anything in `up.sql`
+
+-- Drop dependent objects
+
+DROP VIEW price_feed;
+DROP VIEW market_state;
+DROP VIEW market_daily_volume;
+DROP INDEX mkt_1m_prds_last_24h_idx;
+
+
+-- Remove the added columns
+
+ALTER TABLE market_1m_periods_in_last_day DROP COLUMN base_volume;
+
+ALTER TABLE market_latest_state_event DROP COLUMN base_volume_in_1m_state_tracker;
+
+-- Recreate dependent objects
+
+CREATE INDEX mkt_1m_prds_last_24h_idx
+ON market_1m_periods_in_last_day (market_id)
+INCLUDE (start_time, volume);
+
+CREATE VIEW market_daily_volume AS
+WITH recent_volumes AS (
+    SELECT
+        market_id,
+        COALESCE(SUM(volume), 0::NUMERIC) AS volume
+    FROM market_1m_periods_in_last_day
+    WHERE
+        start_time > NOW() - INTERVAL '24' HOUR
+    GROUP BY
+        market_id
+),
+latest_state_volumes AS (
+    SELECT
+        market_id,
+        CASE
+            WHEN bump_time > NOW() - INTERVAL '24' HOUR
+            THEN COALESCE(volume_in_1m_state_tracker, 0::NUMERIC)
+            ELSE 0::NUMERIC
+        END AS volume_in_1m_state_tracker
+    FROM
+        market_latest_state_event
+)
+SELECT
+    lsv.market_id,
+    COALESCE(rv.volume, 0::NUMERIC) + COALESCE(lsv.volume_in_1m_state_tracker, 0::NUMERIC) AS daily_volume
+FROM
+    latest_state_volumes lsv
+LEFT JOIN
+    recent_volumes rv ON lsv.market_id = rv.market_id;
+
+CREATE VIEW market_state AS
+SELECT
+    mlse.*,
+    dv.daily_volume
+FROM
+    market_latest_state_event mlse
+INNER JOIN
+    market_daily_volume dv ON mlse.market_id = dv.market_id;
+
+CREATE OR REPLACE VIEW price_feed AS
+WITH markets AS (
+    SELECT market_id
+    FROM market_state
+    ORDER BY daily_volume DESC
+),
+swap24 AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    WHERE transaction_timestamp <= CURRENT_TIMESTAMP - interval '1 day'
+    ORDER BY
+        market_id,
+        transaction_timestamp DESC
+),
+first_swap AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    ORDER BY
+        market_id,
+        transaction_timestamp ASC
+)
+SELECT
+    latest_swap.*,
+    COALESCE(swap_open.avg_execution_price_q64, first_swap.avg_execution_price_q64) AS open_price_q64,
+    latest_swap.last_swap_avg_execution_price_q64 AS close_price_q64
+FROM markets
+INNER JOIN market_state AS latest_swap ON markets.market_id = latest_swap.market_id
+INNER JOIN first_swap ON markets.market_id = first_swap.market_id
+LEFT JOIN swap24 AS swap_open ON markets.market_id = swap_open.market_id
+WHERE latest_swap.transaction_timestamp > CURRENT_TIMESTAMP - interval '1 day';

--- a/rust/processor/src/db/postgres/migrations/2024-12-18-143643_add_daily_base_volume/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-12-18-143643_add_daily_base_volume/up.sql
@@ -1,0 +1,125 @@
+-- Your SQL goes here
+-- Keep volume as volume in order to avoid breaking changes
+-- The new column will be named base_volume.
+
+-- Add base volume to market_1m_periods_in_last_day.
+DELETE FROM market_1m_periods_in_last_day;
+ALTER TABLE market_1m_periods_in_last_day ADD COLUMN base_volume NUMERIC NOT NULL;
+INSERT INTO market_1m_periods_in_last_day (market_id, inserted_at, transaction_version, nonce, volume, start_time, base_volume)
+SELECT market_id, inserted_at, transaction_version, market_nonce, volume_quote, start_time, volume_base
+FROM periodic_state_events WHERE period = 'period_1m' AND start_time > NOW() - INTERVAL '24' HOUR;
+
+-- Add base_volume to the index.
+DROP INDEX mkt_1m_prds_last_24h_idx;
+
+CREATE INDEX mkt_1m_prds_last_24h_idx
+ON market_1m_periods_in_last_day (market_id)
+INCLUDE (start_time, volume, base_volume);
+
+-- Add base volume to market_latest_state_event.
+ALTER TABLE market_latest_state_event
+ADD COLUMN base_volume_in_1m_state_tracker NUMERIC DEFAULT 0 NOT NULL;
+ALTER TABLE market_latest_state_event
+ALTER COLUMN base_volume_in_1m_state_tracker DROP DEFAULT;
+UPDATE market_latest_state_event
+SET base_volume_in_1m_state_tracker = COALESCE((
+    SELECT volume_base
+    FROM periodic_state_events AS pse
+    WHERE period = 'period_1m' AND pse.market_id = market_latest_state_event.market_id
+    ORDER BY start_time DESC LIMIT 1
+), 0::NUMERIC);
+
+-- Calculate the 24h rolling volume for each market.
+CREATE OR REPLACE VIEW market_daily_volume AS
+WITH recent_volumes AS (
+    SELECT
+        market_id,
+        COALESCE(SUM(volume), 0::NUMERIC) AS volume,
+        COALESCE(SUM(base_volume), 0::NUMERIC) AS base_volume
+    FROM market_1m_periods_in_last_day
+    WHERE
+        start_time > NOW() - INTERVAL '24' HOUR
+    GROUP BY
+        market_id
+),
+-- Get the latest state tracker volume for each market, aka the unclosed 1min candle volume that hasn't
+-- been emitted as a periodic state event yet.
+latest_state_volumes AS (
+    SELECT
+        market_id,
+        -- Don't include the volume in the state tracker if the bump time is older than 1 day.
+        -- This means the volume calculation period is technically 24 hours + up to 1 minute.
+        -- Note that we use `INTERVAL '24' HOUR` because `'1' DAY` does not always equal 24h.
+        -- See: https://www.postgresql.org/docs/9.1/functions-datetime.html, quote below:
+        -- | this means interval '1 day' does not necessarily equal interval '24 hours'.
+        CASE
+            WHEN bump_time > NOW() - INTERVAL '24' HOUR
+            THEN COALESCE(volume_in_1m_state_tracker, 0::NUMERIC)
+            ELSE 0::NUMERIC
+        END AS volume_in_1m_state_tracker,
+        CASE
+            WHEN bump_time > NOW() - INTERVAL '24' HOUR
+            THEN COALESCE(base_volume_in_1m_state_tracker, 0::NUMERIC)
+            ELSE 0::NUMERIC
+        END AS base_volume_in_1m_state_tracker
+    FROM
+        market_latest_state_event
+)
+-- Left join zero volume markets with > 0 volume markets and latest state volumes, then sum the volumes.
+SELECT
+    lsv.market_id,
+    COALESCE(rv.volume, 0::NUMERIC) + COALESCE(lsv.volume_in_1m_state_tracker, 0::NUMERIC) AS daily_volume,
+    COALESCE(rv.base_volume, 0::NUMERIC) + COALESCE(lsv.base_volume_in_1m_state_tracker, 0::NUMERIC) AS daily_base_volume
+FROM
+    latest_state_volumes lsv
+LEFT JOIN
+    recent_volumes rv ON lsv.market_id = rv.market_id;
+
+-- Recreate this view and its dependent objects to get the new column
+DROP VIEW price_feed;
+DROP VIEW market_state;
+
+CREATE VIEW market_state AS
+SELECT
+    mlse.*,
+    dv.daily_volume,
+    dv.daily_base_volume
+FROM
+    market_latest_state_event mlse
+INNER JOIN
+    market_daily_volume dv ON mlse.market_id = dv.market_id;
+
+CREATE OR REPLACE VIEW price_feed AS
+WITH markets AS (
+    SELECT market_id
+    FROM market_state
+    ORDER BY daily_volume DESC
+),
+swap24 AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    WHERE transaction_timestamp <= CURRENT_TIMESTAMP - interval '1 day'
+    ORDER BY
+        market_id,
+        transaction_timestamp DESC
+),
+first_swap AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    ORDER BY
+        market_id,
+        transaction_timestamp ASC
+)
+SELECT
+    latest_swap.*,
+    COALESCE(swap_open.avg_execution_price_q64, first_swap.avg_execution_price_q64) AS open_price_q64,
+    latest_swap.last_swap_avg_execution_price_q64 AS close_price_q64
+FROM markets
+INNER JOIN market_state AS latest_swap ON markets.market_id = latest_swap.market_id
+INNER JOIN first_swap ON markets.market_id = first_swap.market_id
+LEFT JOIN swap24 AS swap_open ON markets.market_id = swap_open.market_id
+WHERE latest_swap.transaction_timestamp > CURRENT_TIMESTAMP - interval '1 day';

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -1015,6 +1015,7 @@ diesel::table! {
         nonce -> Int8,
         volume -> Numeric,
         start_time -> Timestamp,
+        base_volume -> Numeric,
     }
 }
 
@@ -1063,6 +1064,7 @@ diesel::table! {
         daily_tvl_per_lp_coin_growth -> Numeric,
         in_bonding_curve -> Bool,
         volume_in_1m_state_tracker -> Numeric,
+        base_volume_in_1m_state_tracker -> Numeric,
     }
 }
 


### PR DESCRIPTION
This PR adds daily base volume in addition to the daily quote volume that was already present. To avoid breaking changes in the API, the names of quote volume were not changed to include quote. Note that many of the views recreated are just copied word for word.