### PR TITLE
[ECO-2617] Fix the `event_index` field to use the event index and not the sequence number

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -446,7 +446,7 @@ impl EventWithMarket {
         event_type: &str,
         data: &str,
         txn_version: i64,
-        sequence_number: i64,
+        event_index: i64,
     ) -> Result<Option<Self>> {
         match EmojicoinTypeTag::from_type_str(event_type) {
             Some(EmojicoinTypeTag::PeriodicState) => {
@@ -457,7 +457,7 @@ impl EventWithMarket {
             },
             Some(EmojicoinTypeTag::Swap) => {
                 let mut json_data = serde_json::Value::from_str(data)?;
-                json_data["event_index"] = serde_json::Value::from(sequence_number.to_string());
+                json_data["event_index"] = serde_json::Value::from(event_index.to_string());
                 serde_json::from_value(json_data).map(|inner: SwapEvent| Some(Self::Swap(inner)))
             },
             Some(EmojicoinTypeTag::Chat) => {
@@ -468,7 +468,7 @@ impl EventWithMarket {
             },
             Some(EmojicoinTypeTag::Liquidity) => {
                 let mut json_data = serde_json::Value::from_str(data)?;
-                json_data["event_index"] = serde_json::Value::from(sequence_number.to_string());
+                json_data["event_index"] = serde_json::Value::from(event_index.to_string());
                 serde_json::from_value(json_data)
                     .map(|inner: LiquidityEvent| Some(Self::Liquidity(inner)))
             },

--- a/rust/processor/src/db/common/models/emojicoin_models/models/swap_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/swap_event.rs
@@ -86,7 +86,6 @@ impl SwapEventModel {
         } = state_event;
 
         let SwapEvent {
-            event_index,
             market_id,
             market_nonce,
             swapper,
@@ -105,6 +104,7 @@ impl SwapEventModel {
             time,
             balance_as_fraction_of_circulating_supply_before_q64,
             balance_as_fraction_of_circulating_supply_after_q64,
+            event_index,
             ..
         } = swap_event;
 

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -269,7 +269,7 @@ impl ProcessorTrait for EmojicoinProcessor {
 
                 // Group the market events in this transaction.
                 let mut market_events = vec![];
-                for event in user_txn.events.iter() {
+                for (event_index, event) in user_txn.events.iter().enumerate() {
                     let type_str = event.type_str.as_str();
                     let data = event.data.as_str();
 
@@ -277,7 +277,7 @@ impl ProcessorTrait for EmojicoinProcessor {
                         type_str,
                         data,
                         txn_version,
-                        event.sequence_number as i64,
+                        event_index as i64,
                     )? {
                         Some(evt) => {
                             market_events.push(evt.clone());


### PR DESCRIPTION
The `event_index` field was previously being incorrectly populated with the `sequence_number` instead of the `event_index`.

- [x] Fix that by using the same enumeration method that the core indexer processors use to get the event index.
- [x] Verify manually by looking at the explorer event indexes from transactions generated during e2e tests.