### PR TITLE
[ECO-2602] Arena indexing

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/constants.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/constants.rs
@@ -9,10 +9,18 @@ const STATE: &str = "::emojicoin_dot_fun::State";
 const GLOBAL_STATE: &str = "::emojicoin_dot_fun::GlobalState";
 const LIQUIDITY: &str = "::emojicoin_dot_fun::Liquidity";
 const MARKET: &str = "::emojicoin_dot_fun::Market";
+const ARENA_MELEE: &str = "::emojicoin_arena::Melee";
+const ARENA_ENTER: &str = "::emojicoin_arena::Enter";
+const ARENA_EXIT: &str = "::emojicoin_arena::Exit";
+const ARENA_SWAP: &str = "::emojicoin_arena::Swap";
+const ARENA_VAULT_BALANCE_UPDATE: &str = "::emojicoin_arena::VaultBalanceUpdate";
 
 lazy_static! {
     pub static ref MODULE_ADDRESS: String = std::env::var("EMOJICOIN_MODULE_ADDRESS")
         .expect("EMOJICOIN_MODULE_ADDRESS must be set.")
+        .to_owned();
+    pub static ref ARENA_MODULE_ADDRESS: String = std::env::var("EMOJICOIN_ARENA_MODULE_ADDRESS")
+        .expect("EMOJICOIN_ARENA_MODULE_ADDRESS must be set.")
         .to_owned();
     pub static ref SWAP_EVENT: String = MODULE_ADDRESS.to_owned() + SWAP;
     pub static ref CHAT_EVENT: String = MODULE_ADDRESS.to_owned() + CHAT;
@@ -23,6 +31,12 @@ lazy_static! {
     pub static ref GLOBAL_STATE_EVENT: String = MODULE_ADDRESS.to_owned() + GLOBAL_STATE;
     pub static ref LIQUIDITY_EVENT: String = MODULE_ADDRESS.to_owned() + LIQUIDITY;
     pub static ref MARKET_RESOURCE: String = MODULE_ADDRESS.to_owned() + MARKET;
+    pub static ref ARENA_MELEE_EVENT: String = ARENA_MODULE_ADDRESS.to_owned() + ARENA_MELEE;
+    pub static ref ARENA_ENTER_EVENT: String = ARENA_MODULE_ADDRESS.to_owned() + ARENA_ENTER;
+    pub static ref ARENA_EXIT_EVENT: String = ARENA_MODULE_ADDRESS.to_owned() + ARENA_EXIT;
+    pub static ref ARENA_SWAP_EVENT: String = ARENA_MODULE_ADDRESS.to_owned() + ARENA_SWAP;
+    pub static ref ARENA_VAULT_BALANCE_UPDATE_EVENT: String =
+        ARENA_MODULE_ADDRESS.to_owned() + ARENA_VAULT_BALANCE_UPDATE;
 }
 
 // When a market is first registered, the market_nonce field is emitted in the resulting events as 1.

--- a/rust/processor/src/db/common/models/emojicoin_models/enums.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/enums.rs
@@ -1,10 +1,14 @@
 use super::{
     constants::{
-        CHAT_EVENT, GLOBAL_STATE_EVENT, LIQUIDITY_EVENT, MARKET_REGISTRATION_EVENT,
-        MARKET_RESOURCE, PERIODIC_STATE_EVENT, STATE_EVENT, SWAP_EVENT,
+        ARENA_ENTER_EVENT, ARENA_EXIT_EVENT, ARENA_MELEE_EVENT, ARENA_SWAP_EVENT,
+        ARENA_VAULT_BALANCE_UPDATE_EVENT, CHAT_EVENT, GLOBAL_STATE_EVENT, LIQUIDITY_EVENT,
+        MARKET_REGISTRATION_EVENT, MARKET_RESOURCE, PERIODIC_STATE_EVENT, STATE_EVENT, SWAP_EVENT,
     },
-    json_types::{EventWithMarket, GlobalStateEvent},
+    json_types::{ArenaEvent, EventWithMarket, GlobalStateEvent},
     models::{
+        arena_enter_event::ArenaEnterEventModel, arena_exit_event::ArenaExitEventModel,
+        arena_melee_event::ArenaMeleeEventModel, arena_swap_event::ArenaSwapEventModel,
+        arena_vault_balance_update_event::ArenaVaultBalanceUpdateEventModel,
         chat_event::ChatEventModel, global_state_event::GlobalStateEventModel,
         liquidity_event::LiquidityEventModel,
         market_latest_state_event::MarketLatestStateEventModel,
@@ -146,12 +150,18 @@ pub enum EmojicoinTypeTag {
     GlobalState,
     Liquidity,
     Market,
+    ArenaMelee,
+    ArenaEnter,
+    ArenaExit,
+    ArenaSwap,
+    ArenaVaultBalanceUpdate,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum EmojicoinEvent {
     EventWithMarket(EventWithMarket),
     EventWithoutMarket(GlobalStateEvent),
+    ArenaEvent(ArenaEvent),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, strum::Display)]
@@ -163,6 +173,11 @@ pub enum EmojicoinDbEvent {
     MarketLatestState(MarketLatestStateEventModel),
     GlobalState(GlobalStateEventModel),
     Liquidity(LiquidityEventModel),
+    ArenaMelee(ArenaMeleeEventModel),
+    ArenaEnter(ArenaEnterEventModel),
+    ArenaExit(ArenaExitEventModel),
+    ArenaSwap(ArenaSwapEventModel),
+    ArenaVaultBalanceUpdate(ArenaVaultBalanceUpdateEventModel),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -174,6 +189,11 @@ pub enum EmojicoinEventType {
     State,
     GlobalState,
     Liquidity,
+    ArenaMelee,
+    ArenaEnter,
+    ArenaExit,
+    ArenaSwap,
+    ArenaVaultBalanceUpdate,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -185,6 +205,11 @@ pub enum EmojicoinDbEventType {
     MarketLatestState,
     GlobalState,
     Liquidity,
+    ArenaMelee,
+    ArenaEnter,
+    ArenaExit,
+    ArenaSwap,
+    ArenaVaultBalanceUpdate,
 }
 
 impl From<&EmojicoinEvent> for EmojicoinEventType {
@@ -197,6 +222,13 @@ impl From<&EmojicoinEvent> for EmojicoinEventType {
                 EventWithMarket::Chat(_) => EmojicoinEventType::Chat,
                 EventWithMarket::Liquidity(_) => EmojicoinEventType::Liquidity,
                 EventWithMarket::MarketRegistration(_) => EmojicoinEventType::MarketRegistration,
+            },
+            EmojicoinEvent::ArenaEvent(e) => match e {
+                ArenaEvent::Melee(_) => EmojicoinEventType::ArenaMelee,
+                ArenaEvent::Enter(_) => EmojicoinEventType::ArenaEnter,
+                ArenaEvent::Exit(_) => EmojicoinEventType::ArenaExit,
+                ArenaEvent::Swap(_) => EmojicoinEventType::ArenaSwap,
+                ArenaEvent::VaultBalanceUpdate(_) => EmojicoinEventType::ArenaVaultBalanceUpdate,
             },
             EmojicoinEvent::EventWithoutMarket(_) => EmojicoinEventType::GlobalState,
         }
@@ -213,6 +245,11 @@ impl From<&EmojicoinDbEvent> for EmojicoinDbEventType {
             EmojicoinDbEvent::MarketLatestState(_) => Self::MarketLatestState,
             EmojicoinDbEvent::GlobalState(_) => Self::GlobalState,
             EmojicoinDbEvent::Liquidity(_) => Self::Liquidity,
+            EmojicoinDbEvent::ArenaMelee(_) => Self::ArenaMelee,
+            EmojicoinDbEvent::ArenaEnter(_) => Self::ArenaEnter,
+            EmojicoinDbEvent::ArenaExit(_) => Self::ArenaExit,
+            EmojicoinDbEvent::ArenaSwap(_) => Self::ArenaSwap,
+            EmojicoinDbEvent::ArenaVaultBalanceUpdate(_) => Self::ArenaVaultBalanceUpdate,
         }
     }
 }
@@ -228,6 +265,13 @@ impl EmojicoinTypeTag {
             str if str == GLOBAL_STATE_EVENT.as_str() => Some(Self::GlobalState),
             str if str == LIQUIDITY_EVENT.as_str() => Some(Self::Liquidity),
             str if str == MARKET_RESOURCE.as_str() => Some(Self::Market),
+            str if str == ARENA_MELEE_EVENT.as_str() => Some(Self::ArenaMelee),
+            str if str == ARENA_ENTER_EVENT.as_str() => Some(Self::ArenaEnter),
+            str if str == ARENA_EXIT_EVENT.as_str() => Some(Self::ArenaExit),
+            str if str == ARENA_SWAP_EVENT.as_str() => Some(Self::ArenaSwap),
+            str if str == ARENA_VAULT_BALANCE_UPDATE_EVENT.as_str() => {
+                Some(Self::ArenaVaultBalanceUpdate)
+            },
             _ => None,
         }
     }
@@ -267,6 +311,32 @@ impl EmojicoinDbEvent {
             .iter()
             .cloned()
             .map(Self::MarketLatestState)
+            .collect()
+    }
+
+    pub fn from_arena_melee(events: &[ArenaMeleeEventModel]) -> Vec<Self> {
+        events.iter().cloned().map(Self::ArenaMelee).collect()
+    }
+
+    pub fn from_arena_enter(events: &[ArenaEnterEventModel]) -> Vec<Self> {
+        events.iter().cloned().map(Self::ArenaEnter).collect()
+    }
+
+    pub fn from_arena_exit(events: &[ArenaExitEventModel]) -> Vec<Self> {
+        events.iter().cloned().map(Self::ArenaExit).collect()
+    }
+
+    pub fn from_arena_swap(events: &[ArenaSwapEventModel]) -> Vec<Self> {
+        events.iter().cloned().map(Self::ArenaSwap).collect()
+    }
+
+    pub fn from_arena_vault_balance_update(
+        events: &[ArenaVaultBalanceUpdateEventModel],
+    ) -> Vec<Self> {
+        events
+            .iter()
+            .cloned()
+            .map(Self::ArenaVaultBalanceUpdate)
             .collect()
     }
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -13,6 +13,7 @@ use anyhow::{Context, Result};
 use aptos_protos::transaction::v1::WriteResource;
 use bigdecimal::BigDecimal;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::json;
 use std::str::FromStr;
 
 pub fn serialize_bytes_to_hex_string<S>(element: &Vec<u8>, s: S) -> Result<S::Ok, S::Error>
@@ -420,6 +421,136 @@ pub struct LiquidityEvent {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ExchangeRate {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub base: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub quote: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ArenaMeleeEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub event_index: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub melee_id: i64,
+    #[serde(deserialize_with = "deserialize_and_standardize_address")]
+    pub emojicoin_0_market_address: String,
+    #[serde(deserialize_with = "deserialize_and_standardize_address")]
+    pub emojicoin_1_market_address: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub start_time: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub duration: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub max_match_percentage: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub max_match_amount: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub available_rewards: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ArenaEnterEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub event_index: i64,
+    #[serde(deserialize_with = "deserialize_and_standardize_address")]
+    pub user: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub melee_id: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub input_amount: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub quote_volume: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub integrator_fee: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub match_amount: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub emojicoin_0_proceeds: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub emojicoin_1_proceeds: i64,
+    pub emojicoin_0_exchange_rate: ExchangeRate,
+    pub emojicoin_1_exchange_rate: ExchangeRate,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ArenaExitEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub event_index: i64,
+    #[serde(deserialize_with = "deserialize_and_standardize_address")]
+    pub user: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub melee_id: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub tap_out_fee: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub emojicoin_0_proceeds: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub emojicoin_1_proceeds: i64,
+    pub emojicoin_0_exchange_rate: ExchangeRate,
+    pub emojicoin_1_exchange_rate: ExchangeRate,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ArenaSwapEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub event_index: i64,
+    #[serde(deserialize_with = "deserialize_and_standardize_address")]
+    pub user: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub melee_id: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub quote_volume: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub integrator_fee: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub emojicoin_0_proceeds: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub emojicoin_1_proceeds: i64,
+    pub emojicoin_0_exchange_rate: ExchangeRate,
+    pub emojicoin_1_exchange_rate: ExchangeRate,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ArenaVaultBalanceUpdateEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub event_index: i64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub new_balance: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum EventWithMarket {
     PeriodicState(PeriodicStateEvent),
     State(StateEvent),
@@ -472,6 +603,55 @@ impl EventWithMarket {
                 serde_json::from_value(json_data)
                     .map(|inner: LiquidityEvent| Some(Self::Liquidity(inner)))
             },
+            _ => Ok(None),
+        }
+        .context(format!(
+            "version {} failed! Failed to parse type {}, with data: {:?}",
+            txn_version, event_type, data,
+        ))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum ArenaEvent {
+    Melee(ArenaMeleeEvent),
+    Enter(ArenaEnterEvent),
+    Exit(ArenaExitEvent),
+    Swap(ArenaSwapEvent),
+    VaultBalanceUpdate(ArenaVaultBalanceUpdateEvent),
+}
+
+impl ArenaEvent {
+    pub fn from_event_type(
+        event_type: &str,
+        data: &str,
+        txn_version: i64,
+        event_index: i64,
+    ) -> Result<Option<Self>> {
+        let mut data_map: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(data).unwrap();
+        let mut event_index_map: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_value(json!({
+                "event_index": event_index.to_string()
+            }))
+            .unwrap();
+        data_map.append(&mut event_index_map);
+        let data_object = serde_json::Value::Object(data_map);
+        match EmojicoinTypeTag::from_type_str(event_type) {
+            Some(EmojicoinTypeTag::ArenaMelee) => {
+                serde_json::from_value(data_object).map(|inner| Some(Self::Melee(inner)))
+            },
+            Some(EmojicoinTypeTag::ArenaEnter) => {
+                serde_json::from_value(data_object).map(|inner| Some(Self::Enter(inner)))
+            },
+            Some(EmojicoinTypeTag::ArenaExit) => {
+                serde_json::from_value(data_object).map(|inner| Some(Self::Exit(inner)))
+            },
+            Some(EmojicoinTypeTag::ArenaSwap) => {
+                serde_json::from_value(data_object).map(|inner| Some(Self::Swap(inner)))
+            },
+            Some(EmojicoinTypeTag::ArenaVaultBalanceUpdate) => serde_json::from_value(data_object)
+                .map(|inner| Some(Self::VaultBalanceUpdate(inner))),
             _ => Ok(None),
         }
         .context(format!(

--- a/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -424,10 +424,10 @@ pub struct LiquidityEvent {
 pub struct ExchangeRate {
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub base: i64,
+    pub base: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub quote: i64,
+    pub quote: BigDecimal,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -437,26 +437,26 @@ pub struct ArenaMeleeEvent {
     pub event_index: i64,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub melee_id: i64,
+    pub melee_id: BigDecimal,
     #[serde(deserialize_with = "deserialize_and_standardize_address")]
     pub emojicoin_0_market_address: String,
     #[serde(deserialize_with = "deserialize_and_standardize_address")]
     pub emojicoin_1_market_address: String,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub start_time: i64,
+    pub start_time: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub duration: i64,
+    pub duration: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub max_match_percentage: i64,
+    pub max_match_percentage: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub max_match_amount: i64,
+    pub max_match_amount: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub available_rewards: i64,
+    pub available_rewards: BigDecimal,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -468,25 +468,25 @@ pub struct ArenaEnterEvent {
     pub user: String,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub melee_id: i64,
+    pub melee_id: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub input_amount: i64,
+    pub input_amount: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub quote_volume: i64,
+    pub quote_volume: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub integrator_fee: i64,
+    pub integrator_fee: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub match_amount: i64,
+    pub match_amount: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub emojicoin_0_proceeds: i64,
+    pub emojicoin_0_proceeds: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub emojicoin_1_proceeds: i64,
+    pub emojicoin_1_proceeds: BigDecimal,
     pub emojicoin_0_exchange_rate: ExchangeRate,
     pub emojicoin_1_exchange_rate: ExchangeRate,
 }
@@ -500,16 +500,16 @@ pub struct ArenaExitEvent {
     pub user: String,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub melee_id: i64,
+    pub melee_id: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub tap_out_fee: i64,
+    pub tap_out_fee: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub emojicoin_0_proceeds: i64,
+    pub emojicoin_0_proceeds: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub emojicoin_1_proceeds: i64,
+    pub emojicoin_1_proceeds: BigDecimal,
     pub emojicoin_0_exchange_rate: ExchangeRate,
     pub emojicoin_1_exchange_rate: ExchangeRate,
 }
@@ -523,19 +523,19 @@ pub struct ArenaSwapEvent {
     pub user: String,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub melee_id: i64,
+    pub melee_id: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub quote_volume: i64,
+    pub quote_volume: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub integrator_fee: i64,
+    pub integrator_fee: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub emojicoin_0_proceeds: i64,
+    pub emojicoin_0_proceeds: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub emojicoin_1_proceeds: i64,
+    pub emojicoin_1_proceeds: BigDecimal,
     pub emojicoin_0_exchange_rate: ExchangeRate,
     pub emojicoin_1_exchange_rate: ExchangeRate,
 }
@@ -547,7 +547,7 @@ pub struct ArenaVaultBalanceUpdateEvent {
     pub event_index: i64,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub new_balance: i64,
+    pub new_balance: BigDecimal,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_enter_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_enter_event.rs
@@ -2,6 +2,7 @@ use crate::{
     db::common::models::emojicoin_models::json_types::{ArenaEnterEvent, TxnInfo},
     schema::arena_enter_events,
 };
+use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
@@ -17,18 +18,18 @@ pub struct ArenaEnterEventModel {
     pub transaction_timestamp: chrono::NaiveDateTime,
 
     pub user: String,
-    pub melee_id: i64,
-    pub input_amount: i64,
-    pub quote_volume: i64,
-    pub integrator_fee: i64,
-    pub match_amount: i64,
+    pub melee_id: BigDecimal,
+    pub input_amount: BigDecimal,
+    pub quote_volume: BigDecimal,
+    pub integrator_fee: BigDecimal,
+    pub match_amount: BigDecimal,
 
-    pub emojicoin_0_proceeds: i64,
-    pub emojicoin_1_proceeds: i64,
-    pub emojicoin_0_exchange_rate_base: i64,
-    pub emojicoin_0_exchange_rate_quote: i64,
-    pub emojicoin_1_exchange_rate_base: i64,
-    pub emojicoin_1_exchange_rate_quote: i64,
+    pub emojicoin_0_proceeds: BigDecimal,
+    pub emojicoin_1_proceeds: BigDecimal,
+    pub emojicoin_0_exchange_rate_base: BigDecimal,
+    pub emojicoin_0_exchange_rate_quote: BigDecimal,
+    pub emojicoin_1_exchange_rate_base: BigDecimal,
+    pub emojicoin_1_exchange_rate_quote: BigDecimal,
 }
 
 impl ArenaEnterEventModel {

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_enter_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_enter_event.rs
@@ -1,0 +1,59 @@
+use crate::{
+    db::common::models::emojicoin_models::json_types::{ArenaEnterEvent, TxnInfo},
+    schema::arena_enter_events,
+};
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(transaction_version, event_index))]
+#[diesel(table_name = arena_enter_events)]
+pub struct ArenaEnterEventModel {
+    // Transaction metadata.
+    pub transaction_version: i64,
+    pub event_index: i64,
+    pub sender: String,
+    pub entry_function: Option<String>,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+
+    pub user: String,
+    pub melee_id: i64,
+    pub input_amount: i64,
+    pub quote_volume: i64,
+    pub integrator_fee: i64,
+    pub match_amount: i64,
+
+    pub emojicoin_0_proceeds: i64,
+    pub emojicoin_1_proceeds: i64,
+    pub emojicoin_0_exchange_rate_base: i64,
+    pub emojicoin_0_exchange_rate_quote: i64,
+    pub emojicoin_1_exchange_rate_base: i64,
+    pub emojicoin_1_exchange_rate_quote: i64,
+}
+
+impl ArenaEnterEventModel {
+    pub fn new(txn_info: TxnInfo, arena_enter_event: ArenaEnterEvent) -> ArenaEnterEventModel {
+        ArenaEnterEventModel {
+            // Transaction metadata.
+            transaction_version: txn_info.version,
+            event_index: arena_enter_event.event_index,
+            sender: txn_info.sender.clone(),
+            entry_function: txn_info.entry_function.clone(),
+            transaction_timestamp: txn_info.timestamp,
+
+            user: arena_enter_event.user,
+            melee_id: arena_enter_event.melee_id,
+            input_amount: arena_enter_event.input_amount,
+            quote_volume: arena_enter_event.quote_volume,
+            integrator_fee: arena_enter_event.integrator_fee,
+            match_amount: arena_enter_event.match_amount,
+
+            emojicoin_0_proceeds: arena_enter_event.emojicoin_0_proceeds,
+            emojicoin_1_proceeds: arena_enter_event.emojicoin_1_proceeds,
+            emojicoin_0_exchange_rate_base: arena_enter_event.emojicoin_0_exchange_rate.base,
+            emojicoin_0_exchange_rate_quote: arena_enter_event.emojicoin_0_exchange_rate.quote,
+            emojicoin_1_exchange_rate_base: arena_enter_event.emojicoin_1_exchange_rate.base,
+            emojicoin_1_exchange_rate_quote: arena_enter_event.emojicoin_1_exchange_rate.quote,
+        }
+    }
+}

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_exit_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_exit_event.rs
@@ -1,0 +1,53 @@
+use crate::{
+    db::common::models::emojicoin_models::json_types::{ArenaExitEvent, TxnInfo},
+    schema::arena_exit_events,
+};
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(transaction_version, event_index))]
+#[diesel(table_name = arena_exit_events)]
+pub struct ArenaExitEventModel {
+    // Transaction metadata.
+    pub transaction_version: i64,
+    pub event_index: i64,
+    pub sender: String,
+    pub entry_function: Option<String>,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+
+    pub user: String,
+    pub melee_id: i64,
+    pub tap_out_fee: i64,
+
+    pub emojicoin_0_proceeds: i64,
+    pub emojicoin_1_proceeds: i64,
+    pub emojicoin_0_exchange_rate_base: i64,
+    pub emojicoin_0_exchange_rate_quote: i64,
+    pub emojicoin_1_exchange_rate_base: i64,
+    pub emojicoin_1_exchange_rate_quote: i64,
+}
+
+impl ArenaExitEventModel {
+    pub fn new(txn_info: TxnInfo, arena_exit_event: ArenaExitEvent) -> ArenaExitEventModel {
+        ArenaExitEventModel {
+            // Transaction metadata.
+            transaction_version: txn_info.version,
+            event_index: arena_exit_event.event_index,
+            sender: txn_info.sender.clone(),
+            entry_function: txn_info.entry_function.clone(),
+            transaction_timestamp: txn_info.timestamp,
+
+            user: arena_exit_event.user,
+            melee_id: arena_exit_event.melee_id,
+            tap_out_fee: arena_exit_event.tap_out_fee,
+
+            emojicoin_0_proceeds: arena_exit_event.emojicoin_0_proceeds,
+            emojicoin_1_proceeds: arena_exit_event.emojicoin_1_proceeds,
+            emojicoin_0_exchange_rate_base: arena_exit_event.emojicoin_0_exchange_rate.base,
+            emojicoin_0_exchange_rate_quote: arena_exit_event.emojicoin_0_exchange_rate.quote,
+            emojicoin_1_exchange_rate_base: arena_exit_event.emojicoin_1_exchange_rate.base,
+            emojicoin_1_exchange_rate_quote: arena_exit_event.emojicoin_1_exchange_rate.quote,
+        }
+    }
+}

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_exit_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_exit_event.rs
@@ -2,6 +2,7 @@ use crate::{
     db::common::models::emojicoin_models::json_types::{ArenaExitEvent, TxnInfo},
     schema::arena_exit_events,
 };
+use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
@@ -17,15 +18,15 @@ pub struct ArenaExitEventModel {
     pub transaction_timestamp: chrono::NaiveDateTime,
 
     pub user: String,
-    pub melee_id: i64,
-    pub tap_out_fee: i64,
+    pub melee_id: BigDecimal,
+    pub tap_out_fee: BigDecimal,
 
-    pub emojicoin_0_proceeds: i64,
-    pub emojicoin_1_proceeds: i64,
-    pub emojicoin_0_exchange_rate_base: i64,
-    pub emojicoin_0_exchange_rate_quote: i64,
-    pub emojicoin_1_exchange_rate_base: i64,
-    pub emojicoin_1_exchange_rate_quote: i64,
+    pub emojicoin_0_proceeds: BigDecimal,
+    pub emojicoin_1_proceeds: BigDecimal,
+    pub emojicoin_0_exchange_rate_base: BigDecimal,
+    pub emojicoin_0_exchange_rate_quote: BigDecimal,
+    pub emojicoin_1_exchange_rate_base: BigDecimal,
+    pub emojicoin_1_exchange_rate_quote: BigDecimal,
 }
 
 impl ArenaExitEventModel {

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_melee_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_melee_event.rs
@@ -1,0 +1,49 @@
+use crate::{
+    db::common::models::emojicoin_models::json_types::{ArenaMeleeEvent, TxnInfo},
+    schema::arena_melee_events,
+};
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(melee_id))]
+#[diesel(table_name = arena_melee_events)]
+pub struct ArenaMeleeEventModel {
+    // Transaction metadata.
+    pub transaction_version: i64,
+    pub event_index: i64,
+    pub sender: String,
+    pub entry_function: Option<String>,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+
+    pub melee_id: i64,
+    pub emojicoin_0_market_address: String,
+    pub emojicoin_1_market_address: String,
+    pub start_time: i64,
+    pub duration: i64,
+    pub max_match_percentage: i64,
+    pub max_match_amount: i64,
+    pub available_rewards: i64,
+}
+
+impl ArenaMeleeEventModel {
+    pub fn new(txn_info: TxnInfo, arena_melee_event: ArenaMeleeEvent) -> ArenaMeleeEventModel {
+        ArenaMeleeEventModel {
+            // Transaction metadata.
+            transaction_version: txn_info.version,
+            event_index: arena_melee_event.event_index,
+            sender: txn_info.sender.clone(),
+            entry_function: txn_info.entry_function.clone(),
+            transaction_timestamp: txn_info.timestamp,
+
+            melee_id: arena_melee_event.melee_id,
+            emojicoin_0_market_address: arena_melee_event.emojicoin_0_market_address,
+            emojicoin_1_market_address: arena_melee_event.emojicoin_1_market_address,
+            start_time: arena_melee_event.start_time,
+            duration: arena_melee_event.duration,
+            max_match_percentage: arena_melee_event.max_match_percentage,
+            max_match_amount: arena_melee_event.max_match_amount,
+            available_rewards: arena_melee_event.available_rewards,
+        }
+    }
+}

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_melee_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_melee_event.rs
@@ -2,6 +2,7 @@ use crate::{
     db::common::models::emojicoin_models::json_types::{ArenaMeleeEvent, TxnInfo},
     schema::arena_melee_events,
 };
+use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
@@ -16,14 +17,14 @@ pub struct ArenaMeleeEventModel {
     pub entry_function: Option<String>,
     pub transaction_timestamp: chrono::NaiveDateTime,
 
-    pub melee_id: i64,
+    pub melee_id: BigDecimal,
     pub emojicoin_0_market_address: String,
     pub emojicoin_1_market_address: String,
-    pub start_time: i64,
-    pub duration: i64,
-    pub max_match_percentage: i64,
-    pub max_match_amount: i64,
-    pub available_rewards: i64,
+    pub start_time: BigDecimal,
+    pub duration: BigDecimal,
+    pub max_match_percentage: BigDecimal,
+    pub max_match_amount: BigDecimal,
+    pub available_rewards: BigDecimal,
 }
 
 impl ArenaMeleeEventModel {

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_swap_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_swap_event.rs
@@ -2,6 +2,7 @@ use crate::{
     db::common::models::emojicoin_models::json_types::{ArenaSwapEvent, TxnInfo},
     schema::arena_swap_events,
 };
+use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
@@ -17,16 +18,16 @@ pub struct ArenaSwapEventModel {
     pub transaction_timestamp: chrono::NaiveDateTime,
 
     pub user: String,
-    pub melee_id: i64,
-    pub quote_volume: i64,
-    pub integrator_fee: i64,
+    pub melee_id: BigDecimal,
+    pub quote_volume: BigDecimal,
+    pub integrator_fee: BigDecimal,
 
-    pub emojicoin_0_proceeds: i64,
-    pub emojicoin_1_proceeds: i64,
-    pub emojicoin_0_exchange_rate_base: i64,
-    pub emojicoin_0_exchange_rate_quote: i64,
-    pub emojicoin_1_exchange_rate_base: i64,
-    pub emojicoin_1_exchange_rate_quote: i64,
+    pub emojicoin_0_proceeds: BigDecimal,
+    pub emojicoin_1_proceeds: BigDecimal,
+    pub emojicoin_0_exchange_rate_base: BigDecimal,
+    pub emojicoin_0_exchange_rate_quote: BigDecimal,
+    pub emojicoin_1_exchange_rate_base: BigDecimal,
+    pub emojicoin_1_exchange_rate_quote: BigDecimal,
 }
 
 impl ArenaSwapEventModel {

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_swap_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_swap_event.rs
@@ -1,0 +1,55 @@
+use crate::{
+    db::common::models::emojicoin_models::json_types::{ArenaSwapEvent, TxnInfo},
+    schema::arena_swap_events,
+};
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(transaction_version, event_index))]
+#[diesel(table_name = arena_swap_events)]
+pub struct ArenaSwapEventModel {
+    // Transaction metadata.
+    pub transaction_version: i64,
+    pub event_index: i64,
+    pub sender: String,
+    pub entry_function: Option<String>,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+
+    pub user: String,
+    pub melee_id: i64,
+    pub quote_volume: i64,
+    pub integrator_fee: i64,
+
+    pub emojicoin_0_proceeds: i64,
+    pub emojicoin_1_proceeds: i64,
+    pub emojicoin_0_exchange_rate_base: i64,
+    pub emojicoin_0_exchange_rate_quote: i64,
+    pub emojicoin_1_exchange_rate_base: i64,
+    pub emojicoin_1_exchange_rate_quote: i64,
+}
+
+impl ArenaSwapEventModel {
+    pub fn new(txn_info: TxnInfo, arena_swap_event: ArenaSwapEvent) -> ArenaSwapEventModel {
+        ArenaSwapEventModel {
+            // Transaction metadata.
+            transaction_version: txn_info.version,
+            event_index: arena_swap_event.event_index,
+            sender: txn_info.sender.clone(),
+            entry_function: txn_info.entry_function.clone(),
+            transaction_timestamp: txn_info.timestamp,
+
+            user: arena_swap_event.user,
+            melee_id: arena_swap_event.melee_id,
+            quote_volume: arena_swap_event.quote_volume,
+            integrator_fee: arena_swap_event.integrator_fee,
+
+            emojicoin_0_proceeds: arena_swap_event.emojicoin_0_proceeds,
+            emojicoin_1_proceeds: arena_swap_event.emojicoin_1_proceeds,
+            emojicoin_0_exchange_rate_base: arena_swap_event.emojicoin_0_exchange_rate.base,
+            emojicoin_0_exchange_rate_quote: arena_swap_event.emojicoin_0_exchange_rate.quote,
+            emojicoin_1_exchange_rate_base: arena_swap_event.emojicoin_1_exchange_rate.base,
+            emojicoin_1_exchange_rate_quote: arena_swap_event.emojicoin_1_exchange_rate.quote,
+        }
+    }
+}

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_vault_balance_update_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_vault_balance_update_event.rs
@@ -33,7 +33,6 @@ impl ArenaVaultBalanceUpdateEventModel {
             entry_function: txn_info.entry_function.clone(),
             transaction_timestamp: txn_info.timestamp,
 
-            // Market and state metadata.
             new_balance: arena_vault_balance_update_event.new_balance,
         }
     }

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_vault_balance_update_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_vault_balance_update_event.rs
@@ -2,6 +2,7 @@ use crate::{
     db::common::models::emojicoin_models::json_types::{ArenaVaultBalanceUpdateEvent, TxnInfo},
     schema::arena_vault_balance_update_events,
 };
+use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
@@ -16,7 +17,7 @@ pub struct ArenaVaultBalanceUpdateEventModel {
     pub entry_function: Option<String>,
     pub transaction_timestamp: chrono::NaiveDateTime,
 
-    pub new_balance: i64,
+    pub new_balance: BigDecimal,
 }
 
 impl ArenaVaultBalanceUpdateEventModel {

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_vault_balance_update_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_vault_balance_update_event.rs
@@ -1,0 +1,39 @@
+use crate::{
+    db::common::models::emojicoin_models::json_types::{ArenaVaultBalanceUpdateEvent, TxnInfo},
+    schema::arena_vault_balance_update_events,
+};
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(transaction_version, event_index))]
+#[diesel(table_name = arena_vault_balance_update_events)]
+pub struct ArenaVaultBalanceUpdateEventModel {
+    // Transaction metadata.
+    pub transaction_version: i64,
+    pub event_index: i64,
+    pub sender: String,
+    pub entry_function: Option<String>,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+
+    pub new_balance: i64,
+}
+
+impl ArenaVaultBalanceUpdateEventModel {
+    pub fn new(
+        txn_info: TxnInfo,
+        arena_vault_balance_update_event: ArenaVaultBalanceUpdateEvent,
+    ) -> ArenaVaultBalanceUpdateEventModel {
+        ArenaVaultBalanceUpdateEventModel {
+            // Transaction metadata.
+            transaction_version: txn_info.version,
+            event_index: arena_vault_balance_update_event.event_index,
+            sender: txn_info.sender.clone(),
+            entry_function: txn_info.entry_function.clone(),
+            transaction_timestamp: txn_info.timestamp,
+
+            // Market and state metadata.
+            new_balance: arena_vault_balance_update_event.new_balance,
+        }
+    }
+}

--- a/rust/processor/src/db/common/models/emojicoin_models/models/mod.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/mod.rs
@@ -1,3 +1,8 @@
+pub mod arena_enter_event;
+pub mod arena_exit_event;
+pub mod arena_melee_event;
+pub mod arena_swap_event;
+pub mod arena_vault_balance_update_event;
 pub mod chat_event;
 pub mod global_state_event;
 pub mod liquidity_event;

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
@@ -1,5 +1,8 @@
 use crate::{
     db::common::models::emojicoin_models::models::{
+        arena_enter_event::ArenaEnterEventModel, arena_exit_event::ArenaExitEventModel,
+        arena_melee_event::ArenaMeleeEventModel, arena_swap_event::ArenaSwapEventModel,
+        arena_vault_balance_update_event::ArenaVaultBalanceUpdateEventModel,
         chat_event::ChatEventModel, global_state_event::GlobalStateEventModel,
         liquidity_event::LiquidityEventModel,
         market_latest_state_event::MarketLatestStateEventModel,
@@ -209,6 +212,86 @@ pub fn insert_market_latest_state_event_query(
                 volume_in_1m_state_tracker.eq(excluded(volume_in_1m_state_tracker)),
             ))
             .filter(market_nonce.le(excluded(market_nonce))),
+        None,
+    )
+}
+
+pub fn insert_arena_melee_events_query(
+    items_to_insert: Vec<ArenaMeleeEventModel>,
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
+    use schema::arena_melee_events::dsl::*;
+    (
+        diesel::insert_into(schema::arena_melee_events::table)
+            .values(items_to_insert)
+            .on_conflict(melee_id)
+            .do_nothing(),
+        None,
+    )
+}
+
+pub fn insert_arena_enter_events_query(
+    items_to_insert: Vec<ArenaEnterEventModel>,
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
+    use schema::arena_enter_events::dsl::*;
+    (
+        diesel::insert_into(schema::arena_enter_events::table)
+            .values(items_to_insert)
+            .on_conflict((transaction_version, event_index))
+            .do_nothing(),
+        None,
+    )
+}
+
+pub fn insert_arena_exit_events_query(
+    items_to_insert: Vec<ArenaExitEventModel>,
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
+    use schema::arena_exit_events::dsl::*;
+    (
+        diesel::insert_into(schema::arena_exit_events::table)
+            .values(items_to_insert)
+            .on_conflict((transaction_version, event_index))
+            .do_nothing(),
+        None,
+    )
+}
+
+pub fn insert_arena_swap_events_query(
+    items_to_insert: Vec<ArenaSwapEventModel>,
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
+    use schema::arena_swap_events::dsl::*;
+    (
+        diesel::insert_into(schema::arena_swap_events::table)
+            .values(items_to_insert)
+            .on_conflict((transaction_version, event_index))
+            .do_nothing(),
+        None,
+    )
+}
+
+pub fn insert_arena_vault_balance_update_events_query(
+    items_to_insert: Vec<ArenaVaultBalanceUpdateEventModel>,
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
+    use schema::arena_vault_balance_update_events::dsl::*;
+    (
+        diesel::insert_into(schema::arena_vault_balance_update_events::table)
+            .values(items_to_insert)
+            .on_conflict((transaction_version, event_index))
+            .do_nothing(),
         None,
     )
 }

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/down.sql
@@ -5,14 +5,14 @@ DROP INDEX latest_swap_by_market_address;
 DROP TRIGGER update_position_enter_trigger ON arena_enter_events;
 DROP TRIGGER update_position_exit_trigger ON arena_exit_events;
 DROP TRIGGER update_position_swap_trigger ON arena_swap_events;
-DROP TRIGGER snapshot_leaderboard_trigger ON arena_melee_events;
+DROP TRIGGER save_leaderboard_history_trigger ON arena_melee_events;
 
 DROP FUNCTION update_position_enter;
 DROP FUNCTION update_position_exit;
 DROP FUNCTION update_position_swap;
-DROP FUNCTION snapshot_leaderboard;
+DROP FUNCTION save_leaderboard_history;
 
-DROP FUNCTION arena_leaderboard;
+DROP VIEW arena_leaderboard;
 
 DROP TABLE arena_melee_events;
 DROP TABLE arena_enter_events;

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/down.sql
@@ -1,0 +1,23 @@
+-- This file should undo anything in `up.sql`
+
+DROP INDEX latest_swap_by_market_address;
+
+DROP TRIGGER update_position_enter_trigger ON arena_enter_events;
+DROP TRIGGER update_position_exit_trigger ON arena_exit_events;
+DROP TRIGGER update_position_swap_trigger ON arena_swap_events;
+DROP TRIGGER snapshot_leaderboard_trigger ON arena_melee_events;
+
+DROP FUNCTION update_position_enter;
+DROP FUNCTION update_position_exit;
+DROP FUNCTION update_position_swap;
+DROP FUNCTION snapshot_leaderboard;
+
+DROP FUNCTION arena_leaderboard;
+
+DROP TABLE arena_melee_events;
+DROP TABLE arena_enter_events;
+DROP TABLE arena_exit_events;
+DROP TABLE arena_swap_events;
+DROP TABLE arena_vault_balance_update_events;
+DROP TABLE arena_leaderboard_history;
+DROP TABLE arena_positions;

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/down.sql
@@ -12,6 +12,16 @@ DROP FUNCTION update_position_exit;
 DROP FUNCTION update_position_swap;
 DROP FUNCTION save_leaderboard_history;
 
+DROP TRIGGER update_arena_info_enter_trigger ON arena_enter_events;
+DROP TRIGGER update_arena_info_exit_trigger ON arena_exit_events;
+DROP TRIGGER update_arena_info_swap_trigger ON arena_swap_events;
+DROP TRIGGER create_melee_info_trigger ON arena_melee_events;
+
+DROP FUNCTION update_arena_info_enter;
+DROP FUNCTION update_arena_info_exit;
+DROP FUNCTION update_arena_info_swap;
+DROP FUNCTION create_melee_info;
+
 DROP VIEW arena_leaderboard;
 
 DROP TABLE arena_melee_events;
@@ -21,3 +31,4 @@ DROP TABLE arena_swap_events;
 DROP TABLE arena_vault_balance_update_events;
 DROP TABLE arena_leaderboard_history;
 DROP TABLE arena_positions;
+DROP TABLE arena_info;

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
@@ -121,7 +121,22 @@ CREATE TABLE arena_leaderboard_history (
     PRIMARY KEY ("user", melee_id)
 );
 
--- Functions
+CREATE TABLE arena_info (
+    melee_id NUMERIC NOT NULL PRIMARY KEY,
+    volume NUMERIC NOT NULL,
+    rewards_remaining NUMERIC NOT NULL,
+    apt_locked NUMERIC NOT NULL,
+
+    -- Redundant information to avoid multiple queries/joins
+    emojicoin_0_market_address TEXT,
+    emojicoin_1_market_address TEXT,
+    start_time NUMERIC,
+    duration NUMERIC,
+    max_match_percentage NUMERIC,
+    max_match_amount NUMERIC
+);
+
+-- Views
 
 CREATE VIEW arena_leaderboard AS
 WITH melee AS (
@@ -197,7 +212,13 @@ CREATE FUNCTION update_position_exit() RETURNS trigger AS $$
             open = false,
             emojicoin_0_balance = 0,
             emojicoin_1_balance = 0,
-            withdrawals = arena_positions.withdrawals + NEW.emojicoin_0_proceeds * NEW.emojicoin_0_exchange_rate_base / NEW.emojicoin_0_exchange_rate_quote + NEW.emojicoin_1_proceeds * NEW.emojicoin_1_exchange_rate_base / NEW.emojicoin_1_exchange_rate_quote,
+            withdrawals = arena_positions.withdrawals
+                + NEW.emojicoin_0_proceeds
+                    / NEW.emojicoin_0_exchange_rate_base
+                    * NEW.emojicoin_0_exchange_rate_quote
+                + NEW.emojicoin_1_proceeds
+                    / NEW.emojicoin_1_exchange_rate_base
+                    * NEW.emojicoin_1_exchange_rate_quote,
             deposits = arena_positions.deposits + NEW.tap_out_fee
         WHERE arena_positions."user" = NEW."user" AND arena_positions.melee_id = NEW.melee_id;
         RETURN NEW;
@@ -240,6 +261,113 @@ CREATE TRIGGER update_position_swap_trigger AFTER INSERT ON arena_swap_events
 
 CREATE TRIGGER save_leaderboard_history_trigger BEFORE INSERT ON arena_melee_events
     FOR EACH ROW EXECUTE FUNCTION save_leaderboard_history();
+
+-- Since events can be inserted out of order, we need to handle both the case
+-- where the Melee event is inserted first and where the Enter event is
+-- inserted first.
+CREATE FUNCTION create_melee_info() RETURNS trigger AS $$
+    BEGIN
+        INSERT INTO arena_info (
+            melee_id,
+            volume,
+            rewards_remaining,
+            apt_locked,
+            emojicoin_0_market_address,
+            emojicoin_1_market_address,
+            start_time,
+            duration,
+            max_match_percentage,
+            max_match_amount
+        ) VALUES (
+            NEW.melee_id,
+            0,
+            NEW.available_rewards,
+            0,
+            NEW.emojicoin_0_market_address,
+            NEW.emojicoin_1_market_address,
+            NEW.start_time,
+            NEW.duration,
+            NEW.max_match_percentage,
+            NEW.max_match_amount
+        )
+        ON CONFLICT (melee_id) DO
+        UPDATE SET
+            rewards_remaining = arena_info.rewards_remaining + NEW.available_rewards,
+            emojicoin_0_market_address = NEW.emojicoin_0_market_address,
+            emojicoin_1_market_address = NEW.emojicoin_1_market_address,
+            start_time = NEW.start_time,
+            duration = NEW.duration,
+            max_match_percentage = NEW.max_match_percentage,
+            max_match_amount = NEW.max_match_amount
+        WHERE arena_info.melee_id = NEW.melee_id;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+-- Since events can be inserted out of order, we need to handle both the case
+-- where the Melee event is inserted first and where the Enter event is
+-- inserted first.
+CREATE FUNCTION update_arena_info_enter() RETURNS trigger AS $$
+    BEGIN
+        INSERT INTO arena_info (
+            melee_id,
+            volume,
+            rewards_remaining,
+            apt_locked
+        ) VALUES (
+            NEW.melee_id,
+            NEW.quote_volume,
+            0 - NEW.match_amount,
+            NEW.quote_volume
+        )
+        ON CONFLICT (melee_id) DO
+        UPDATE SET
+            volume = arena_info.volume + NEW.quote_volume,
+            rewards_remaining = arena_info.rewards_remaining - NEW.match_amount,
+            apt_locked = arena_info.apt_locked + NEW.quote_volume
+        WHERE arena_info.melee_id = NEW.melee_id;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION update_arena_info_exit() RETURNS trigger AS $$
+    BEGIN
+        UPDATE arena_info SET
+            -- We check that this never underflows due to rounding errors
+            apt_locked = GREATEST(ROUND(
+                arena_info.apt_locked
+                    - NEW.emojicoin_0_proceeds
+                        / NEW.emojicoin_0_exchange_rate_base
+                        * NEW.emojicoin_0_exchange_rate_quote
+                    - NEW.emojicoin_1_proceeds
+                        / NEW.emojicoin_1_exchange_rate_base
+                        * NEW.emojicoin_1_exchange_rate_quote
+            ), 0)
+        WHERE arena_info.melee_id = NEW.melee_id;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION update_arena_info_swap() RETURNS trigger AS $$
+    BEGIN
+        UPDATE arena_info SET
+            volume = arena_info.volume + NEW.quote_volume
+        WHERE arena_info.melee_id = NEW.melee_id;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER create_melee_info_trigger AFTER INSERT ON arena_melee_events
+    FOR EACH ROW EXECUTE FUNCTION create_melee_info();
+
+CREATE TRIGGER update_arena_info_enter_trigger AFTER INSERT ON arena_enter_events
+    FOR EACH ROW EXECUTE FUNCTION update_arena_info_enter();
+
+CREATE TRIGGER update_arena_info_exit_trigger AFTER INSERT ON arena_exit_events
+    FOR EACH ROW EXECUTE FUNCTION update_arena_info_exit();
+
+CREATE TRIGGER update_arena_info_swap_trigger AFTER INSERT ON arena_swap_events
+    FOR EACH ROW EXECUTE FUNCTION update_arena_info_swap();
 
 -- Indices
 

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
@@ -1,0 +1,256 @@
+-- Raw events
+
+CREATE TABLE arena_melee_events (
+    transaction_version BIGINT NOT NULL,
+    event_index BIGINT NOT NULL,
+    sender VARCHAR(66) NOT NULL,
+    entry_function VARCHAR(200),
+    transaction_timestamp TIMESTAMP NOT NULL,
+    inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    melee_id BIGINT NOT NULL PRIMARY KEY,
+    emojicoin_0_market_address TEXT NOT NULL,
+    emojicoin_1_market_address TEXT NOT NULL,
+    start_time BIGINT NOT NULL,
+    duration BIGINT NOT NULL,
+    max_match_percentage BIGINT NOT NULL,
+    max_match_amount BIGINT NOT NULL,
+    available_rewards BIGINT NOT NULL
+);
+
+CREATE TABLE arena_enter_events (
+    transaction_version BIGINT NOT NULL,
+    event_index BIGINT NOT NULL,
+    sender VARCHAR(66) NOT NULL,
+    entry_function VARCHAR(200),
+    transaction_timestamp TIMESTAMP NOT NULL,
+    inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    "user" TEXT NOT NULL,
+    melee_id BIGINT NOT NULL,
+    input_amount BIGINT NOT NULL,
+    quote_volume BIGINT NOT NULL,
+    integrator_fee BIGINT NOT NULL,
+    match_amount BIGINT NOT NULL,
+    emojicoin_0_proceeds BIGINT NOT NULL,
+    emojicoin_1_proceeds BIGINT NOT NULL,
+    emojicoin_0_exchange_rate_base BIGINT NOT NULL,
+    emojicoin_0_exchange_rate_quote BIGINT NOT NULL,
+    emojicoin_1_exchange_rate_base BIGINT NOT NULL,
+    emojicoin_1_exchange_rate_quote BIGINT NOT NULL,
+
+    PRIMARY KEY (transaction_version, event_index)
+);
+
+CREATE TABLE arena_exit_events (
+    transaction_version BIGINT NOT NULL,
+    event_index BIGINT NOT NULL,
+    sender VARCHAR(66) NOT NULL,
+    entry_function VARCHAR(200),
+    transaction_timestamp TIMESTAMP NOT NULL,
+    inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    "user" TEXT NOT NULL,
+    melee_id BIGINT NOT NULL,
+    tap_out_fee BIGINT NOT NULL,
+    emojicoin_0_proceeds BIGINT NOT NULL,
+    emojicoin_1_proceeds BIGINT NOT NULL,
+    emojicoin_0_exchange_rate_base BIGINT NOT NULL,
+    emojicoin_0_exchange_rate_quote BIGINT NOT NULL,
+    emojicoin_1_exchange_rate_base BIGINT NOT NULL,
+    emojicoin_1_exchange_rate_quote BIGINT NOT NULL,
+
+    PRIMARY KEY (transaction_version, event_index)
+);
+
+CREATE TABLE arena_swap_events (
+    transaction_version BIGINT NOT NULL,
+    event_index BIGINT NOT NULL,
+    sender VARCHAR(66) NOT NULL,
+    entry_function VARCHAR(200),
+    transaction_timestamp TIMESTAMP NOT NULL,
+    inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    "user" TEXT NOT NULL,
+    melee_id BIGINT NOT NULL,
+    quote_volume BIGINT NOT NULL,
+    integrator_fee BIGINT NOT NULL,
+    emojicoin_0_proceeds BIGINT NOT NULL,
+    emojicoin_1_proceeds BIGINT NOT NULL,
+    emojicoin_0_exchange_rate_base BIGINT NOT NULL,
+    emojicoin_0_exchange_rate_quote BIGINT NOT NULL,
+    emojicoin_1_exchange_rate_base BIGINT NOT NULL,
+    emojicoin_1_exchange_rate_quote BIGINT NOT NULL,
+
+    PRIMARY KEY (transaction_version, event_index)
+);
+
+CREATE TABLE arena_vault_balance_update_events (
+    transaction_version BIGINT NOT NULL,
+    event_index BIGINT NOT NULL,
+    sender VARCHAR(66) NOT NULL,
+    entry_function VARCHAR(200),
+    transaction_timestamp TIMESTAMP NOT NULL,
+    inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    new_balance BIGINT NOT NULL,
+
+    PRIMARY KEY (transaction_version, event_index)
+);
+
+-- Derived data
+
+CREATE TABLE arena_positions (
+    "user" TEXT NOT NULL,
+    melee_id BIGINT NOT NULL,
+    open BOOL NOT NULL,
+    emojicoin_0_balance BIGINT NOT NULL,
+    emojicoin_1_balance BIGINT NOT NULL,
+    profits BIGINT NOT NULL,
+    losses BIGINT NOT NULL,
+
+    PRIMARY KEY ("user", melee_id)
+);
+
+CREATE TABLE arena_leaderboard_history (
+    "user" TEXT NOT NULL,
+    melee_id BIGINT NOT NULL,
+    profits BIGINT NOT NULL,
+    losses BIGINT NOT NULL,
+
+    PRIMARY KEY ("user", melee_id)
+);
+
+-- Functions
+
+CREATE OR REPLACE FUNCTION arena_leaderboard() RETURNS TABLE(
+    "user" TEXT,
+    open BOOL,
+    emojicoin_0_balance BIGINT,
+    emojicoin_1_balance BIGINT,
+    profits BIGINT,
+    losses BIGINT,
+    pnl NUMERIC
+)
+AS $$
+WITH melee AS (
+    SELECT * FROM arena_melee_events ORDER BY melee_id DESC LIMIT 1
+), price_emojicoin_0 AS (
+    SELECT avg_execution_price_q64::numeric / POW(2,64) AS price FROM swap_events
+    WHERE market_address = (SELECT emojicoin_0_market_address FROM arena_melee_events WHERE melee_id = (SELECT melee_id FROM melee))
+    ORDER BY market_nonce DESC
+    LIMIT 1
+), price_emojicoin_1 AS (
+    SELECT avg_execution_price_q64::numeric / POW(2,64) AS price FROM swap_events
+    WHERE market_address = (SELECT emojicoin_1_market_address FROM arena_melee_events WHERE melee_id = (SELECT melee_id FROM melee))
+    ORDER BY market_nonce DESC
+    LIMIT 1
+), realized_position AS (
+    SELECT
+        "user",
+        open,
+        emojicoin_0_balance,
+        emojicoin_1_balance,
+        profits +
+            emojicoin_0_balance * (SELECT * FROM price_emojicoin_0) +
+            emojicoin_1_balance * (SELECT * FROM price_emojicoin_1),
+        losses,
+        (profits +
+            emojicoin_0_balance * (SELECT * FROM price_emojicoin_0) +
+            emojicoin_1_balance * (SELECT * FROM price_emojicoin_1))::numeric /
+        losses::numeric * 100::numeric AS pnl
+    FROM arena_positions WHERE melee_id = (SELECT melee_id FROM melee)
+)
+SELECT * FROM realized_position
+$$ LANGUAGE SQL;
+
+-- Triggers to update derived data
+
+-- Insert a new position in the positions table.
+--
+-- If position already exists, it means that this is a top off and we handle it
+-- as such.
+CREATE FUNCTION update_position_enter() RETURNS trigger AS $$
+    BEGIN
+        INSERT INTO arena_positions (
+            "user",
+            melee_id,
+            open,
+            emojicoin_0_balance,
+            emojicoin_1_balance,
+            profits,
+            losses
+        ) VALUES (
+            NEW."user",
+            NEW.melee_id,
+            true,
+            NEW.emojicoin_0_proceeds,
+            NEW.emojicoin_1_proceeds,
+            0,
+            NEW.input_amount + NEW.match_amount
+        )
+        ON CONFLICT ("user", melee_id) DO
+        UPDATE SET
+            open = true,
+            emojicoin_0_balance = arena_positions.emojicoin_0_balance + NEW.emojicoin_0_proceeds,
+            emojicoin_1_balance = arena_positions.emojicoin_1_balance + NEW.emojicoin_1_proceeds,
+            losses = arena_positions.losses + NEW.input_amount + NEW.match_amount
+        WHERE arena_positions."user" = NEW."user" AND arena_positions.melee_id = NEW.melee_id;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+-- Mark the position as closed and update profits and losses.
+CREATE FUNCTION update_position_exit() RETURNS trigger AS $$
+    BEGIN
+        UPDATE arena_positions SET
+            open = false,
+            emojicoin_0_balance = 0,
+            emojicoin_1_balance = 0,
+            profits = arena_positions.profits + NEW.emojicoin_0_proceeds * NEW.emojicoin_0_exchange_rate_base / NEW.emojicoin_0_exchange_rate_quote + NEW.emojicoin_1_proceeds * NEW.emojicoin_1_exchange_rate_base / NEW.emojicoin_1_exchange_rate_quote,
+            losses = arena_positions.losses + NEW.tap_out_fee
+        WHERE arena_positions."user" = NEW."user" AND arena_positions.melee_id = NEW.melee_id;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+-- Update the emojicoin balances according to the swap data.
+CREATE FUNCTION update_position_swap() RETURNS trigger AS $$
+    BEGIN
+        UPDATE arena_positions SET
+            emojicoin_0_balance = NEW.emojicoin_0_proceeds,
+            emojicoin_1_balance = NEW.emojicoin_1_proceeds
+        WHERE arena_positions."user" = NEW."user" AND arena_positions.melee_id = NEW.melee_id;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+-- Save a snapshot of the leaderboard in the leaderboard history table.
+CREATE FUNCTION snapshot_leaderboard() RETURNS trigger AS $$
+    BEGIN
+        INSERT INTO arena_leaderboard_history
+        SELECT
+            "user",
+            NEW.melee_id - 1,
+            profits,
+            losses
+        FROM arena_leaderboard();
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_position_enter_trigger AFTER INSERT ON arena_enter_events
+    FOR EACH ROW EXECUTE FUNCTION update_position_enter();
+
+CREATE TRIGGER update_position_exit_trigger AFTER INSERT ON arena_exit_events
+    FOR EACH ROW EXECUTE FUNCTION update_position_exit();
+
+CREATE TRIGGER update_position_swap_trigger AFTER INSERT ON arena_swap_events
+    FOR EACH ROW EXECUTE FUNCTION update_position_swap();
+
+CREATE TRIGGER snapshot_leaderboard_trigger BEFORE INSERT ON arena_melee_events
+    FOR EACH ROW EXECUTE FUNCTION snapshot_leaderboard();
+
+-- Indices
+
+CREATE INDEX latest_swap_by_market_address ON swap_events (market_address, market_nonce DESC);

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
@@ -106,8 +106,8 @@ CREATE TABLE arena_positions (
     open BOOL NOT NULL,
     emojicoin_0_balance NUMERIC NOT NULL,
     emojicoin_1_balance NUMERIC NOT NULL,
-    profits NUMERIC NOT NULL,
-    losses NUMERIC NOT NULL,
+    withdrawals NUMERIC NOT NULL,
+    deposits NUMERIC NOT NULL,
 
     PRIMARY KEY ("user", melee_id)
 );
@@ -123,16 +123,7 @@ CREATE TABLE arena_leaderboard_history (
 
 -- Functions
 
-CREATE OR REPLACE FUNCTION arena_leaderboard() RETURNS TABLE(
-    "user" TEXT,
-    open BOOL,
-    emojicoin_0_balance NUMERIC,
-    emojicoin_1_balance NUMERIC,
-    profits NUMERIC,
-    losses NUMERIC,
-    pnl NUMERIC
-)
-AS $$
+CREATE VIEW arena_leaderboard AS
 WITH melee AS (
     SELECT * FROM arena_melee_events ORDER BY melee_id DESC LIMIT 1
 ), price_emojicoin_0 AS (
@@ -151,18 +142,17 @@ WITH melee AS (
         open,
         emojicoin_0_balance,
         emojicoin_1_balance,
-        profits +
+        withdrawals +
             emojicoin_0_balance * (SELECT * FROM price_emojicoin_0) +
-            emojicoin_1_balance * (SELECT * FROM price_emojicoin_1),
-        losses,
-        (profits +
-            emojicoin_0_balance * (SELECT * FROM price_emojicoin_0) +
-            emojicoin_1_balance * (SELECT * FROM price_emojicoin_1)) /
-        losses * 100 AS pnl
+            emojicoin_1_balance * (SELECT * FROM price_emojicoin_1) AS profits,
+        deposits AS losses
     FROM arena_positions WHERE melee_id = (SELECT melee_id FROM melee)
 )
-SELECT * FROM realized_position
-$$ LANGUAGE SQL;
+SELECT
+    *,
+    profits / losses * 100 - 100 AS pnl,
+    profits - losses AS pnl_octas
+FROM realized_position;
 
 -- Triggers to update derived data
 
@@ -178,8 +168,8 @@ CREATE FUNCTION update_position_enter() RETURNS trigger AS $$
             open,
             emojicoin_0_balance,
             emojicoin_1_balance,
-            profits,
-            losses
+            withdrawals,
+            deposits
         ) VALUES (
             NEW."user",
             NEW.melee_id,
@@ -194,21 +184,21 @@ CREATE FUNCTION update_position_enter() RETURNS trigger AS $$
             open = true,
             emojicoin_0_balance = arena_positions.emojicoin_0_balance + NEW.emojicoin_0_proceeds,
             emojicoin_1_balance = arena_positions.emojicoin_1_balance + NEW.emojicoin_1_proceeds,
-            losses = arena_positions.losses + NEW.input_amount + NEW.match_amount
+            deposits = arena_positions.deposits + NEW.input_amount + NEW.match_amount
         WHERE arena_positions."user" = NEW."user" AND arena_positions.melee_id = NEW.melee_id;
         RETURN NEW;
     END;
 $$ LANGUAGE plpgsql;
 
--- Mark the position as closed and update profits and losses.
+-- Mark the position as closed and update withdrawals and deposits.
 CREATE FUNCTION update_position_exit() RETURNS trigger AS $$
     BEGIN
         UPDATE arena_positions SET
             open = false,
             emojicoin_0_balance = 0,
             emojicoin_1_balance = 0,
-            profits = arena_positions.profits + NEW.emojicoin_0_proceeds * NEW.emojicoin_0_exchange_rate_base / NEW.emojicoin_0_exchange_rate_quote + NEW.emojicoin_1_proceeds * NEW.emojicoin_1_exchange_rate_base / NEW.emojicoin_1_exchange_rate_quote,
-            losses = arena_positions.losses + NEW.tap_out_fee
+            withdrawals = arena_positions.withdrawals + NEW.emojicoin_0_proceeds * NEW.emojicoin_0_exchange_rate_base / NEW.emojicoin_0_exchange_rate_quote + NEW.emojicoin_1_proceeds * NEW.emojicoin_1_exchange_rate_base / NEW.emojicoin_1_exchange_rate_quote,
+            deposits = arena_positions.deposits + NEW.tap_out_fee
         WHERE arena_positions."user" = NEW."user" AND arena_positions.melee_id = NEW.melee_id;
         RETURN NEW;
     END;
@@ -226,7 +216,7 @@ CREATE FUNCTION update_position_swap() RETURNS trigger AS $$
 $$ LANGUAGE plpgsql;
 
 -- Save a snapshot of the leaderboard in the leaderboard history table.
-CREATE FUNCTION snapshot_leaderboard() RETURNS trigger AS $$
+CREATE FUNCTION save_leaderboard_history() RETURNS trigger AS $$
     BEGIN
         INSERT INTO arena_leaderboard_history
         SELECT
@@ -234,7 +224,7 @@ CREATE FUNCTION snapshot_leaderboard() RETURNS trigger AS $$
             NEW.melee_id - 1,
             profits,
             losses
-        FROM arena_leaderboard();
+        FROM arena_leaderboard;
         RETURN NEW;
     END;
 $$ LANGUAGE plpgsql;
@@ -248,8 +238,8 @@ CREATE TRIGGER update_position_exit_trigger AFTER INSERT ON arena_exit_events
 CREATE TRIGGER update_position_swap_trigger AFTER INSERT ON arena_swap_events
     FOR EACH ROW EXECUTE FUNCTION update_position_swap();
 
-CREATE TRIGGER snapshot_leaderboard_trigger BEFORE INSERT ON arena_melee_events
-    FOR EACH ROW EXECUTE FUNCTION snapshot_leaderboard();
+CREATE TRIGGER save_leaderboard_history_trigger BEFORE INSERT ON arena_melee_events
+    FOR EACH ROW EXECUTE FUNCTION save_leaderboard_history();
 
 -- Indices
 

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
@@ -8,14 +8,14 @@ CREATE TABLE arena_melee_events (
     transaction_timestamp TIMESTAMP NOT NULL,
     inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
 
-    melee_id BIGINT NOT NULL PRIMARY KEY,
+    melee_id NUMERIC NOT NULL PRIMARY KEY,
     emojicoin_0_market_address TEXT NOT NULL,
     emojicoin_1_market_address TEXT NOT NULL,
-    start_time BIGINT NOT NULL,
-    duration BIGINT NOT NULL,
-    max_match_percentage BIGINT NOT NULL,
-    max_match_amount BIGINT NOT NULL,
-    available_rewards BIGINT NOT NULL
+    start_time NUMERIC NOT NULL,
+    duration NUMERIC NOT NULL,
+    max_match_percentage NUMERIC NOT NULL,
+    max_match_amount NUMERIC NOT NULL,
+    available_rewards NUMERIC NOT NULL
 );
 
 CREATE TABLE arena_enter_events (
@@ -27,17 +27,17 @@ CREATE TABLE arena_enter_events (
     inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
 
     "user" TEXT NOT NULL,
-    melee_id BIGINT NOT NULL,
-    input_amount BIGINT NOT NULL,
-    quote_volume BIGINT NOT NULL,
-    integrator_fee BIGINT NOT NULL,
-    match_amount BIGINT NOT NULL,
-    emojicoin_0_proceeds BIGINT NOT NULL,
-    emojicoin_1_proceeds BIGINT NOT NULL,
-    emojicoin_0_exchange_rate_base BIGINT NOT NULL,
-    emojicoin_0_exchange_rate_quote BIGINT NOT NULL,
-    emojicoin_1_exchange_rate_base BIGINT NOT NULL,
-    emojicoin_1_exchange_rate_quote BIGINT NOT NULL,
+    melee_id NUMERIC NOT NULL,
+    input_amount NUMERIC NOT NULL,
+    quote_volume NUMERIC NOT NULL,
+    integrator_fee NUMERIC NOT NULL,
+    match_amount NUMERIC NOT NULL,
+    emojicoin_0_proceeds NUMERIC NOT NULL,
+    emojicoin_1_proceeds NUMERIC NOT NULL,
+    emojicoin_0_exchange_rate_base NUMERIC NOT NULL,
+    emojicoin_0_exchange_rate_quote NUMERIC NOT NULL,
+    emojicoin_1_exchange_rate_base NUMERIC NOT NULL,
+    emojicoin_1_exchange_rate_quote NUMERIC NOT NULL,
 
     PRIMARY KEY (transaction_version, event_index)
 );
@@ -51,14 +51,14 @@ CREATE TABLE arena_exit_events (
     inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
 
     "user" TEXT NOT NULL,
-    melee_id BIGINT NOT NULL,
-    tap_out_fee BIGINT NOT NULL,
-    emojicoin_0_proceeds BIGINT NOT NULL,
-    emojicoin_1_proceeds BIGINT NOT NULL,
-    emojicoin_0_exchange_rate_base BIGINT NOT NULL,
-    emojicoin_0_exchange_rate_quote BIGINT NOT NULL,
-    emojicoin_1_exchange_rate_base BIGINT NOT NULL,
-    emojicoin_1_exchange_rate_quote BIGINT NOT NULL,
+    melee_id NUMERIC NOT NULL,
+    tap_out_fee NUMERIC NOT NULL,
+    emojicoin_0_proceeds NUMERIC NOT NULL,
+    emojicoin_1_proceeds NUMERIC NOT NULL,
+    emojicoin_0_exchange_rate_base NUMERIC NOT NULL,
+    emojicoin_0_exchange_rate_quote NUMERIC NOT NULL,
+    emojicoin_1_exchange_rate_base NUMERIC NOT NULL,
+    emojicoin_1_exchange_rate_quote NUMERIC NOT NULL,
 
     PRIMARY KEY (transaction_version, event_index)
 );
@@ -72,15 +72,15 @@ CREATE TABLE arena_swap_events (
     inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
 
     "user" TEXT NOT NULL,
-    melee_id BIGINT NOT NULL,
-    quote_volume BIGINT NOT NULL,
-    integrator_fee BIGINT NOT NULL,
-    emojicoin_0_proceeds BIGINT NOT NULL,
-    emojicoin_1_proceeds BIGINT NOT NULL,
-    emojicoin_0_exchange_rate_base BIGINT NOT NULL,
-    emojicoin_0_exchange_rate_quote BIGINT NOT NULL,
-    emojicoin_1_exchange_rate_base BIGINT NOT NULL,
-    emojicoin_1_exchange_rate_quote BIGINT NOT NULL,
+    melee_id NUMERIC NOT NULL,
+    quote_volume NUMERIC NOT NULL,
+    integrator_fee NUMERIC NOT NULL,
+    emojicoin_0_proceeds NUMERIC NOT NULL,
+    emojicoin_1_proceeds NUMERIC NOT NULL,
+    emojicoin_0_exchange_rate_base NUMERIC NOT NULL,
+    emojicoin_0_exchange_rate_quote NUMERIC NOT NULL,
+    emojicoin_1_exchange_rate_base NUMERIC NOT NULL,
+    emojicoin_1_exchange_rate_quote NUMERIC NOT NULL,
 
     PRIMARY KEY (transaction_version, event_index)
 );
@@ -93,7 +93,7 @@ CREATE TABLE arena_vault_balance_update_events (
     transaction_timestamp TIMESTAMP NOT NULL,
     inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
 
-    new_balance BIGINT NOT NULL,
+    new_balance NUMERIC NOT NULL,
 
     PRIMARY KEY (transaction_version, event_index)
 );
@@ -102,21 +102,21 @@ CREATE TABLE arena_vault_balance_update_events (
 
 CREATE TABLE arena_positions (
     "user" TEXT NOT NULL,
-    melee_id BIGINT NOT NULL,
+    melee_id NUMERIC NOT NULL,
     open BOOL NOT NULL,
-    emojicoin_0_balance BIGINT NOT NULL,
-    emojicoin_1_balance BIGINT NOT NULL,
-    profits BIGINT NOT NULL,
-    losses BIGINT NOT NULL,
+    emojicoin_0_balance NUMERIC NOT NULL,
+    emojicoin_1_balance NUMERIC NOT NULL,
+    profits NUMERIC NOT NULL,
+    losses NUMERIC NOT NULL,
 
     PRIMARY KEY ("user", melee_id)
 );
 
 CREATE TABLE arena_leaderboard_history (
     "user" TEXT NOT NULL,
-    melee_id BIGINT NOT NULL,
-    profits BIGINT NOT NULL,
-    losses BIGINT NOT NULL,
+    melee_id NUMERIC NOT NULL,
+    profits NUMERIC NOT NULL,
+    losses NUMERIC NOT NULL,
 
     PRIMARY KEY ("user", melee_id)
 );
@@ -126,10 +126,10 @@ CREATE TABLE arena_leaderboard_history (
 CREATE OR REPLACE FUNCTION arena_leaderboard() RETURNS TABLE(
     "user" TEXT,
     open BOOL,
-    emojicoin_0_balance BIGINT,
-    emojicoin_1_balance BIGINT,
-    profits BIGINT,
-    losses BIGINT,
+    emojicoin_0_balance NUMERIC,
+    emojicoin_1_balance NUMERIC,
+    profits NUMERIC,
+    losses NUMERIC,
     pnl NUMERIC
 )
 AS $$
@@ -157,8 +157,8 @@ WITH melee AS (
         losses,
         (profits +
             emojicoin_0_balance * (SELECT * FROM price_emojicoin_0) +
-            emojicoin_1_balance * (SELECT * FROM price_emojicoin_1))::numeric /
-        losses::numeric * 100::numeric AS pnl
+            emojicoin_1_balance * (SELECT * FROM price_emojicoin_1)) /
+        losses * 100 AS pnl
     FROM arena_positions WHERE melee_id = (SELECT melee_id FROM melee)
 )
 SELECT * FROM realized_position

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
@@ -150,7 +150,7 @@ WITH melee AS (
 )
 SELECT
     *,
-    profits / losses * 100 - 100 AS pnl,
+    profits / losses * 100 - 100 AS pnl_percent,
     profits - losses AS pnl_octas
 FROM realized_position;
 

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -95,6 +95,132 @@ diesel::table! {
 }
 
 diesel::table! {
+    arena_enter_events (transaction_version, event_index) {
+        transaction_version -> Int8,
+        event_index -> Int8,
+        #[max_length = 66]
+        sender -> Varchar,
+        #[max_length = 200]
+        entry_function -> Nullable<Varchar>,
+        transaction_timestamp -> Timestamp,
+        inserted_at -> Timestamp,
+        user -> Text,
+        melee_id -> Int8,
+        input_amount -> Int8,
+        quote_volume -> Int8,
+        integrator_fee -> Int8,
+        match_amount -> Int8,
+        emojicoin_0_proceeds -> Int8,
+        emojicoin_1_proceeds -> Int8,
+        emojicoin_0_exchange_rate_base -> Int8,
+        emojicoin_0_exchange_rate_quote -> Int8,
+        emojicoin_1_exchange_rate_base -> Int8,
+        emojicoin_1_exchange_rate_quote -> Int8,
+    }
+}
+
+diesel::table! {
+    arena_exit_events (transaction_version, event_index) {
+        transaction_version -> Int8,
+        event_index -> Int8,
+        #[max_length = 66]
+        sender -> Varchar,
+        #[max_length = 200]
+        entry_function -> Nullable<Varchar>,
+        transaction_timestamp -> Timestamp,
+        inserted_at -> Timestamp,
+        user -> Text,
+        melee_id -> Int8,
+        tap_out_fee -> Int8,
+        emojicoin_0_proceeds -> Int8,
+        emojicoin_1_proceeds -> Int8,
+        emojicoin_0_exchange_rate_base -> Int8,
+        emojicoin_0_exchange_rate_quote -> Int8,
+        emojicoin_1_exchange_rate_base -> Int8,
+        emojicoin_1_exchange_rate_quote -> Int8,
+    }
+}
+
+diesel::table! {
+    arena_leaderboard_history (user, melee_id) {
+        user -> Text,
+        melee_id -> Int8,
+        profits -> Int8,
+        losses -> Int8,
+    }
+}
+
+diesel::table! {
+    arena_melee_events (melee_id) {
+        transaction_version -> Int8,
+        event_index -> Int8,
+        #[max_length = 66]
+        sender -> Varchar,
+        #[max_length = 200]
+        entry_function -> Nullable<Varchar>,
+        transaction_timestamp -> Timestamp,
+        inserted_at -> Timestamp,
+        melee_id -> Int8,
+        emojicoin_0_market_address -> Text,
+        emojicoin_1_market_address -> Text,
+        start_time -> Int8,
+        duration -> Int8,
+        max_match_percentage -> Int8,
+        max_match_amount -> Int8,
+        available_rewards -> Int8,
+    }
+}
+
+diesel::table! {
+    arena_positions (user, melee_id) {
+        user -> Text,
+        melee_id -> Int8,
+        open -> Bool,
+        emojicoin_0_balance -> Int8,
+        emojicoin_1_balance -> Int8,
+        profits -> Int8,
+        losses -> Int8,
+    }
+}
+
+diesel::table! {
+    arena_swap_events (transaction_version, event_index) {
+        transaction_version -> Int8,
+        event_index -> Int8,
+        #[max_length = 66]
+        sender -> Varchar,
+        #[max_length = 200]
+        entry_function -> Nullable<Varchar>,
+        transaction_timestamp -> Timestamp,
+        inserted_at -> Timestamp,
+        user -> Text,
+        melee_id -> Int8,
+        quote_volume -> Int8,
+        integrator_fee -> Int8,
+        emojicoin_0_proceeds -> Int8,
+        emojicoin_1_proceeds -> Int8,
+        emojicoin_0_exchange_rate_base -> Int8,
+        emojicoin_0_exchange_rate_quote -> Int8,
+        emojicoin_1_exchange_rate_base -> Int8,
+        emojicoin_1_exchange_rate_quote -> Int8,
+    }
+}
+
+diesel::table! {
+    arena_vault_balance_update_events (transaction_version, event_index) {
+        transaction_version -> Int8,
+        event_index -> Int8,
+        #[max_length = 66]
+        sender -> Varchar,
+        #[max_length = 200]
+        entry_function -> Nullable<Varchar>,
+        transaction_timestamp -> Timestamp,
+        inserted_at -> Timestamp,
+        new_balance -> Int8,
+    }
+}
+
+diesel::table! {
     block_metadata_transactions (version) {
         version -> Int8,
         block_height -> Int8,
@@ -1659,6 +1785,13 @@ diesel::allow_tables_to_appear_in_same_query!(
     ans_lookup_v2,
     ans_primary_name,
     ans_primary_name_v2,
+    arena_enter_events,
+    arena_exit_events,
+    arena_leaderboard_history,
+    arena_melee_events,
+    arena_positions,
+    arena_swap_events,
+    arena_vault_balance_update_events,
     block_metadata_transactions,
     chat_events,
     coin_activities,

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -105,17 +105,17 @@ diesel::table! {
         transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
         user -> Text,
-        melee_id -> Int8,
-        input_amount -> Int8,
-        quote_volume -> Int8,
-        integrator_fee -> Int8,
-        match_amount -> Int8,
-        emojicoin_0_proceeds -> Int8,
-        emojicoin_1_proceeds -> Int8,
-        emojicoin_0_exchange_rate_base -> Int8,
-        emojicoin_0_exchange_rate_quote -> Int8,
-        emojicoin_1_exchange_rate_base -> Int8,
-        emojicoin_1_exchange_rate_quote -> Int8,
+        melee_id -> Numeric,
+        input_amount -> Numeric,
+        quote_volume -> Numeric,
+        integrator_fee -> Numeric,
+        match_amount -> Numeric,
+        emojicoin_0_proceeds -> Numeric,
+        emojicoin_1_proceeds -> Numeric,
+        emojicoin_0_exchange_rate_base -> Numeric,
+        emojicoin_0_exchange_rate_quote -> Numeric,
+        emojicoin_1_exchange_rate_base -> Numeric,
+        emojicoin_1_exchange_rate_quote -> Numeric,
     }
 }
 
@@ -130,23 +130,23 @@ diesel::table! {
         transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
         user -> Text,
-        melee_id -> Int8,
-        tap_out_fee -> Int8,
-        emojicoin_0_proceeds -> Int8,
-        emojicoin_1_proceeds -> Int8,
-        emojicoin_0_exchange_rate_base -> Int8,
-        emojicoin_0_exchange_rate_quote -> Int8,
-        emojicoin_1_exchange_rate_base -> Int8,
-        emojicoin_1_exchange_rate_quote -> Int8,
+        melee_id -> Numeric,
+        tap_out_fee -> Numeric,
+        emojicoin_0_proceeds -> Numeric,
+        emojicoin_1_proceeds -> Numeric,
+        emojicoin_0_exchange_rate_base -> Numeric,
+        emojicoin_0_exchange_rate_quote -> Numeric,
+        emojicoin_1_exchange_rate_base -> Numeric,
+        emojicoin_1_exchange_rate_quote -> Numeric,
     }
 }
 
 diesel::table! {
     arena_leaderboard_history (user, melee_id) {
         user -> Text,
-        melee_id -> Int8,
-        profits -> Int8,
-        losses -> Int8,
+        melee_id -> Numeric,
+        profits -> Numeric,
+        losses -> Numeric,
     }
 }
 
@@ -160,26 +160,26 @@ diesel::table! {
         entry_function -> Nullable<Varchar>,
         transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
-        melee_id -> Int8,
+        melee_id -> Numeric,
         emojicoin_0_market_address -> Text,
         emojicoin_1_market_address -> Text,
-        start_time -> Int8,
-        duration -> Int8,
-        max_match_percentage -> Int8,
-        max_match_amount -> Int8,
-        available_rewards -> Int8,
+        start_time -> Numeric,
+        duration -> Numeric,
+        max_match_percentage -> Numeric,
+        max_match_amount -> Numeric,
+        available_rewards -> Numeric,
     }
 }
 
 diesel::table! {
     arena_positions (user, melee_id) {
         user -> Text,
-        melee_id -> Int8,
+        melee_id -> Numeric,
         open -> Bool,
-        emojicoin_0_balance -> Int8,
-        emojicoin_1_balance -> Int8,
-        profits -> Int8,
-        losses -> Int8,
+        emojicoin_0_balance -> Numeric,
+        emojicoin_1_balance -> Numeric,
+        profits -> Numeric,
+        losses -> Numeric,
     }
 }
 
@@ -194,15 +194,15 @@ diesel::table! {
         transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
         user -> Text,
-        melee_id -> Int8,
-        quote_volume -> Int8,
-        integrator_fee -> Int8,
-        emojicoin_0_proceeds -> Int8,
-        emojicoin_1_proceeds -> Int8,
-        emojicoin_0_exchange_rate_base -> Int8,
-        emojicoin_0_exchange_rate_quote -> Int8,
-        emojicoin_1_exchange_rate_base -> Int8,
-        emojicoin_1_exchange_rate_quote -> Int8,
+        melee_id -> Numeric,
+        quote_volume -> Numeric,
+        integrator_fee -> Numeric,
+        emojicoin_0_proceeds -> Numeric,
+        emojicoin_1_proceeds -> Numeric,
+        emojicoin_0_exchange_rate_base -> Numeric,
+        emojicoin_0_exchange_rate_quote -> Numeric,
+        emojicoin_1_exchange_rate_base -> Numeric,
+        emojicoin_1_exchange_rate_quote -> Numeric,
     }
 }
 
@@ -216,7 +216,7 @@ diesel::table! {
         entry_function -> Nullable<Varchar>,
         transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
-        new_balance -> Int8,
+        new_balance -> Numeric,
     }
 }
 

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -142,6 +142,21 @@ diesel::table! {
 }
 
 diesel::table! {
+    arena_info (melee_id) {
+        melee_id -> Numeric,
+        volume -> Numeric,
+        rewards_remaining -> Numeric,
+        apt_locked -> Numeric,
+        emojicoin_0_market_address -> Nullable<Text>,
+        emojicoin_1_market_address -> Nullable<Text>,
+        start_time -> Nullable<Numeric>,
+        duration -> Nullable<Numeric>,
+        max_match_percentage -> Nullable<Numeric>,
+        max_match_amount -> Nullable<Numeric>,
+    }
+}
+
+diesel::table! {
     arena_leaderboard_history (user, melee_id) {
         user -> Text,
         melee_id -> Numeric,
@@ -1787,6 +1802,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     ans_primary_name_v2,
     arena_enter_events,
     arena_exit_events,
+    arena_info,
     arena_leaderboard_history,
     arena_melee_events,
     arena_positions,

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -178,8 +178,8 @@ diesel::table! {
         open -> Bool,
         emojicoin_0_balance -> Numeric,
         emojicoin_1_balance -> Numeric,
-        profits -> Numeric,
-        losses -> Numeric,
+        withdrawals -> Numeric,
+        deposits -> Numeric,
     }
 }
 

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -86,25 +86,29 @@ impl Debug for EmojicoinProcessor {
     }
 }
 
+struct InsertEvents<'a> {
+    market_registration_events: &'a [MarketRegistrationEventModel],
+    swap_events: &'a [SwapEventModel],
+    chat_events: &'a [ChatEventModel],
+    liquidity_events: &'a [LiquidityEventModel],
+    periodic_state_events: &'a [PeriodicStateEventModel],
+    global_state_events: &'a [GlobalStateEventModel],
+    market_latest_state_events: &'a [MarketLatestStateEventModel],
+    market_1m_periods: &'a [MarketOneMinutePeriodsInLastDayModel],
+    user_pools: &'a [UserLiquidityPoolsModel],
+    arena_melee_events: &'a [ArenaMeleeEventModel],
+    arena_enter_events: &'a [ArenaEnterEventModel],
+    arena_exit_events: &'a [ArenaExitEventModel],
+    arena_swap_events: &'a [ArenaSwapEventModel],
+    arena_vault_balance_update_events: &'a [ArenaVaultBalanceUpdateEventModel],
+}
+
 async fn insert_to_db(
     conn: ArcDbPool,
     name: &'static str,
     start_version: u64,
     end_version: u64,
-    market_registration_events: &[MarketRegistrationEventModel],
-    swap_events: &[SwapEventModel],
-    chat_events: &[ChatEventModel],
-    liquidity_events: &[LiquidityEventModel],
-    periodic_state_events: &[PeriodicStateEventModel],
-    global_state_events: &[GlobalStateEventModel],
-    market_latest_state_events: &[MarketLatestStateEventModel],
-    market_1m_periods: &[MarketOneMinutePeriodsInLastDayModel],
-    user_pools: &[UserLiquidityPoolsModel],
-    arena_melee_events: &[ArenaMeleeEventModel],
-    arena_enter_events: &[ArenaEnterEventModel],
-    arena_exit_events: &[ArenaExitEventModel],
-    arena_swap_events: &[ArenaSwapEventModel],
-    arena_vault_balance_update_events: &[ArenaVaultBalanceUpdateEventModel],
+    insert_events: InsertEvents<'_>,
     per_table_chunk_sizes: &AHashMap<String, usize>,
 ) -> Result<(), diesel::result::Error> {
     tracing::trace!(
@@ -113,6 +117,22 @@ async fn insert_to_db(
         end_version = end_version,
         "Inserting to db",
     );
+    let InsertEvents {
+        market_registration_events,
+        swap_events,
+        chat_events,
+        liquidity_events,
+        periodic_state_events,
+        global_state_events,
+        market_latest_state_events,
+        market_1m_periods,
+        user_pools,
+        arena_melee_events,
+        arena_enter_events,
+        arena_exit_events,
+        arena_swap_events,
+        arena_vault_balance_update_events,
+    } = insert_events;
     let market_registration = execute_in_chunks(
         conn.clone(),
         insert_market_registration_events_query,
@@ -367,18 +387,13 @@ impl ProcessorTrait for EmojicoinProcessor {
                                     txn_info.clone(),
                                     global_event,
                                 ));
-                            } else {
-                                match ArenaEvent::from_event_type(
-                                    type_str,
-                                    data,
-                                    txn_version,
-                                    event_index as i64,
-                                )? {
-                                    Some(evt) => {
-                                        arena_events.push(evt.clone());
-                                    },
-                                    _ => {},
-                                }
+                            } else if let Some(evt) = ArenaEvent::from_event_type(
+                                type_str,
+                                data,
+                                txn_version,
+                                event_index as i64,
+                            )? {
+                                arena_events.push(evt.clone());
                             }
                         },
                     }
@@ -572,20 +587,22 @@ impl ProcessorTrait for EmojicoinProcessor {
             self.name(),
             start_version,
             end_version,
-            &register_events_db,
-            &swap_events_db,
-            &chat_events_db,
-            &liquidity_events_db,
-            &periodic_state_events_db,
-            &global_state_events_db,
-            &market_latest_state_events,
-            &market_1m_periods,
-            user_pools_db.into_values().collect_vec().as_slice(),
-            &arena_melee_events_db,
-            &arena_enter_events_db,
-            &arena_exit_events_db,
-            &arena_swap_events_db,
-            &arena_vault_balance_update_events_db,
+            InsertEvents {
+                market_registration_events: &register_events_db,
+                swap_events: &swap_events_db,
+                chat_events: &chat_events_db,
+                liquidity_events: &liquidity_events_db,
+                periodic_state_events: &periodic_state_events_db,
+                global_state_events: &global_state_events_db,
+                market_latest_state_events: &market_latest_state_events,
+                market_1m_periods: &market_1m_periods,
+                user_pools: user_pools_db.into_values().collect_vec().as_slice(),
+                arena_melee_events: &arena_melee_events_db,
+                arena_enter_events: &arena_enter_events_db,
+                arena_exit_events: &arena_exit_events_db,
+                arena_swap_events: &arena_swap_events_db,
+                arena_vault_balance_update_events: &arena_vault_balance_update_events_db,
+            },
             &self.per_table_chunk_sizes,
         )
         .await;

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -195,16 +195,6 @@ async fn insert_to_db(
         ),
     );
 
-    let arena_melee = execute_in_chunks(
-        conn.clone(),
-        insert_arena_melee_events_query,
-        arena_melee_events,
-        get_config_table_chunk_size::<ArenaMeleeEventModel>(
-            "arena_melee_events",
-            per_table_chunk_sizes,
-        ),
-    );
-
     let arena_enter = execute_in_chunks(
         conn.clone(),
         insert_arena_enter_events_query,
@@ -241,6 +231,16 @@ async fn insert_to_db(
         arena_vault_balance_update_events,
         get_config_table_chunk_size::<ArenaVaultBalanceUpdateEventModel>(
             "arena_vault_balance_update_events",
+            per_table_chunk_sizes,
+        ),
+    );
+
+    let arena_melee = execute_in_chunks(
+        conn.clone(),
+        insert_arena_melee_events_query,
+        arena_melee_events,
+        get_config_table_chunk_size::<ArenaMeleeEventModel>(
+            "arena_melee_events",
             per_table_chunk_sizes,
         ),
     );

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -3,10 +3,13 @@ use crate::{
         enums::Trigger,
         event_utils::EventGroupBuilder,
         json_types::{
-            BumpEvent, EventGroup, EventWithMarket, GlobalStateEvent, InstantaneousStats,
-            MarketResource, TxnInfo,
+            ArenaEvent, BumpEvent, EventGroup, EventWithMarket, GlobalStateEvent,
+            InstantaneousStats, MarketResource, TxnInfo,
         },
         models::{
+            arena_enter_event::ArenaEnterEventModel, arena_exit_event::ArenaExitEventModel,
+            arena_melee_event::ArenaMeleeEventModel, arena_swap_event::ArenaSwapEventModel,
+            arena_vault_balance_update_event::ArenaVaultBalanceUpdateEventModel,
             chat_event::ChatEventModel, global_state_event::GlobalStateEventModel,
             liquidity_event::LiquidityEventModel,
             market_1m_periods_in_last_day::MarketOneMinutePeriodsInLastDayModel,
@@ -17,10 +20,13 @@ use crate::{
             user_liquidity_pools::UserLiquidityPoolsModel,
         },
         queries::insertion_queries::{
-            delete_unregistered_markets_query, insert_chat_events_query, insert_global_events,
-            insert_liquidity_events_query, insert_market_latest_state_event_query,
-            insert_market_registration_events_query, insert_periodic_state_events_query,
-            insert_swap_events_query, insert_user_liquidity_pools_query,
+            delete_unregistered_markets_query, insert_arena_enter_events_query,
+            insert_arena_exit_events_query, insert_arena_melee_events_query,
+            insert_arena_swap_events_query, insert_arena_vault_balance_update_events_query,
+            insert_chat_events_query, insert_global_events, insert_liquidity_events_query,
+            insert_market_latest_state_event_query, insert_market_registration_events_query,
+            insert_periodic_state_events_query, insert_swap_events_query,
+            insert_user_liquidity_pools_query,
         },
     },
     emojicoin_dot_fun::EmojicoinDbEvent,
@@ -94,6 +100,11 @@ async fn insert_to_db(
     market_latest_state_events: &[MarketLatestStateEventModel],
     market_1m_periods: &[MarketOneMinutePeriodsInLastDayModel],
     user_pools: &[UserLiquidityPoolsModel],
+    arena_melee_events: &[ArenaMeleeEventModel],
+    arena_enter_events: &[ArenaEnterEventModel],
+    arena_exit_events: &[ArenaExitEventModel],
+    arena_swap_events: &[ArenaSwapEventModel],
+    arena_vault_balance_update_events: &[ArenaVaultBalanceUpdateEventModel],
     per_table_chunk_sizes: &AHashMap<String, usize>,
 ) -> Result<(), diesel::result::Error> {
     tracing::trace!(
@@ -184,7 +195,57 @@ async fn insert_to_db(
         ),
     );
 
-    let (m, u, s, c, l, per, g, pools, lse, update_1mins) = tokio::join!(
+    let arena_melee = execute_in_chunks(
+        conn.clone(),
+        insert_arena_melee_events_query,
+        arena_melee_events,
+        get_config_table_chunk_size::<ArenaMeleeEventModel>(
+            "arena_melee_events",
+            per_table_chunk_sizes,
+        ),
+    );
+
+    let arena_enter = execute_in_chunks(
+        conn.clone(),
+        insert_arena_enter_events_query,
+        arena_enter_events,
+        get_config_table_chunk_size::<ArenaEnterEventModel>(
+            "arena_enter_events",
+            per_table_chunk_sizes,
+        ),
+    );
+
+    let arena_exit = execute_in_chunks(
+        conn.clone(),
+        insert_arena_exit_events_query,
+        arena_exit_events,
+        get_config_table_chunk_size::<ArenaExitEventModel>(
+            "arena_exit_events",
+            per_table_chunk_sizes,
+        ),
+    );
+
+    let arena_swap = execute_in_chunks(
+        conn.clone(),
+        insert_arena_swap_events_query,
+        arena_swap_events,
+        get_config_table_chunk_size::<ArenaSwapEventModel>(
+            "arena_swap_events",
+            per_table_chunk_sizes,
+        ),
+    );
+
+    let arena_vault_balance_update = execute_in_chunks(
+        conn.clone(),
+        insert_arena_vault_balance_update_events_query,
+        arena_vault_balance_update_events,
+        get_config_table_chunk_size::<ArenaVaultBalanceUpdateEventModel>(
+            "arena_vault_balance_update_events",
+            per_table_chunk_sizes,
+        ),
+    );
+
+    let (m, u, s, c, l, per, g, pools, lse, update_1mins, am, aen, aex, asw, avbu) = tokio::join!(
         market_registration,
         unregistered_markets_update,
         swap,
@@ -195,9 +256,14 @@ async fn insert_to_db(
         lp_pools,
         latest_state_events,
         update_one_min_periods,
+        arena_melee,
+        arena_enter,
+        arena_exit,
+        arena_swap,
+        arena_vault_balance_update,
     );
 
-    for res in [m, u, s, c, l, per, g, pools, lse] {
+    for res in [m, u, s, c, l, per, g, pools, lse, am, aen, aex, asw, avbu] {
         res?;
     }
 
@@ -229,6 +295,11 @@ impl ProcessorTrait for EmojicoinProcessor {
         let mut periodic_state_events_db = vec![];
         let mut global_state_events_db = vec![];
         let mut period_data = vec![];
+        let mut arena_melee_events_db = vec![];
+        let mut arena_enter_events_db = vec![];
+        let mut arena_exit_events_db = vec![];
+        let mut arena_swap_events_db = vec![];
+        let mut arena_vault_balance_update_events_db = vec![];
         // Store the writeset changes for each market in the transaction so we can lazily parse them later only for the
         // latest event for that market. We may get several writeset changes for the same market across all the transactions.
         let mut latest_market_resources: AHashMap<
@@ -269,6 +340,7 @@ impl ProcessorTrait for EmojicoinProcessor {
 
                 // Group the market events in this transaction.
                 let mut market_events = vec![];
+                let mut arena_events = vec![];
                 for (event_index, event) in user_txn.events.iter().enumerate() {
                     let type_str = event.type_str.as_str();
                     let data = event.data.as_str();
@@ -295,6 +367,18 @@ impl ProcessorTrait for EmojicoinProcessor {
                                     txn_info.clone(),
                                     global_event,
                                 ));
+                            } else {
+                                match ArenaEvent::from_event_type(
+                                    type_str,
+                                    data,
+                                    txn_version,
+                                    event_index as i64,
+                                )? {
+                                    Some(evt) => {
+                                        arena_events.push(evt.clone());
+                                    },
+                                    _ => {},
+                                }
                             }
                         },
                     }
@@ -370,20 +454,29 @@ impl ProcessorTrait for EmojicoinProcessor {
 
                     match bump_event {
                         BumpEvent::MarketRegistration(event) => {
-                            let mkt_registration_model =
-                                MarketRegistrationEventModel::new(txn_info, event, state_event);
+                            let mkt_registration_model = MarketRegistrationEventModel::new(
+                                txn_info.clone(),
+                                event,
+                                state_event,
+                            );
                             register_events_db.push(mkt_registration_model);
                         },
                         BumpEvent::Chat(chat) => {
-                            chat_events_db.push(ChatEventModel::new(txn_info, chat, state_event));
+                            chat_events_db.push(ChatEventModel::new(
+                                txn_info.clone(),
+                                chat,
+                                state_event,
+                            ));
                         },
                         BumpEvent::Swap(swap) => {
-                            let swap_model = SwapEventModel::new(txn_info, swap, state_event);
+                            let swap_model =
+                                SwapEventModel::new(txn_info.clone(), swap, state_event);
                             swap_events_db.push(swap_model);
                         },
                         BumpEvent::Liquidity(event) => {
                             let market_addr = market_addr.clone();
-                            let evt_model = LiquidityEventModel::new(txn_info, event, state_event);
+                            let evt_model =
+                                LiquidityEventModel::new(txn_info.clone(), event, state_event);
                             liquidity_events_db.push(evt_model.clone());
 
                             // Only insert the latest pool activity for a user in this transaction.
@@ -405,6 +498,26 @@ impl ProcessorTrait for EmojicoinProcessor {
                                     }
                                 })
                                 .or_insert(new_pool);
+                        },
+                    }
+                }
+                for event in arena_events {
+                    match event {
+                        ArenaEvent::Melee(melee) => arena_melee_events_db
+                            .push(ArenaMeleeEventModel::new(txn_info.clone(), melee)),
+                        ArenaEvent::Enter(enter) => arena_enter_events_db
+                            .push(ArenaEnterEventModel::new(txn_info.clone(), enter)),
+                        ArenaEvent::Exit(exit) => arena_exit_events_db
+                            .push(ArenaExitEventModel::new(txn_info.clone(), exit)),
+                        ArenaEvent::Swap(swap) => arena_swap_events_db
+                            .push(ArenaSwapEventModel::new(txn_info.clone(), swap)),
+                        ArenaEvent::VaultBalanceUpdate(vault_balance_update) => {
+                            arena_vault_balance_update_events_db.push(
+                                ArenaVaultBalanceUpdateEventModel::new(
+                                    txn_info.clone(),
+                                    vault_balance_update,
+                                ),
+                            )
                         },
                     }
                 }
@@ -440,6 +553,13 @@ impl ProcessorTrait for EmojicoinProcessor {
             EmojicoinDbEvent::from_periodic_state_events(&periodic_state_events_db),
             EmojicoinDbEvent::from_global_state_events(&global_state_events_db),
             EmojicoinDbEvent::from_market_latest_state_events(&market_latest_state_events),
+            EmojicoinDbEvent::from_arena_melee(&arena_melee_events_db),
+            EmojicoinDbEvent::from_arena_enter(&arena_enter_events_db),
+            EmojicoinDbEvent::from_arena_exit(&arena_exit_events_db),
+            EmojicoinDbEvent::from_arena_swap(&arena_swap_events_db),
+            EmojicoinDbEvent::from_arena_vault_balance_update(
+                &arena_vault_balance_update_events_db,
+            ),
         ]
         .into_iter()
         .flatten()
@@ -461,6 +581,11 @@ impl ProcessorTrait for EmojicoinProcessor {
             &market_latest_state_events,
             &market_1m_periods,
             user_pools_db.into_values().collect_vec().as_slice(),
+            &arena_melee_events_db,
+            &arena_enter_events_db,
+            &arena_exit_events_db,
+            &arena_swap_events_db,
+            &arena_vault_balance_update_events_db,
             &self.per_table_chunk_sizes,
         )
         .await;


### PR DESCRIPTION
This PR adds:

- Migration to add:
  - New arena events tables.
  - Derived data tables (positions and leaderboards).
  - Triggers to update derived tables.
- Types and logic in Rust.
- Needed boilerplate to make everything work.

# Status

Currently tested by interacting with the arena package using the CLI.

More testing is needed.