### PR TITLE
[ECO-2674] Fix daily base volume fields

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
@@ -210,6 +210,7 @@ pub fn insert_market_latest_state_event_query(
                 daily_tvl_per_lp_coin_growth.eq(excluded(daily_tvl_per_lp_coin_growth)),
                 in_bonding_curve.eq(excluded(in_bonding_curve)),
                 volume_in_1m_state_tracker.eq(excluded(volume_in_1m_state_tracker)),
+                base_volume_in_1m_state_tracker.eq(excluded(base_volume_in_1m_state_tracker)),
             ))
             .filter(market_nonce.le(excluded(market_nonce))),
         None,

--- a/rust/processor/src/db/postgres/migrations/2024-12-18-143643_add_daily_base_volume/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-12-18-143643_add_daily_base_volume/up.sql
@@ -18,16 +18,7 @@ INCLUDE (start_time, volume, base_volume);
 
 -- Add base volume to market_latest_state_event.
 ALTER TABLE market_latest_state_event
-ADD COLUMN base_volume_in_1m_state_tracker NUMERIC DEFAULT 0 NOT NULL;
-ALTER TABLE market_latest_state_event
-ALTER COLUMN base_volume_in_1m_state_tracker DROP DEFAULT;
-UPDATE market_latest_state_event
-SET base_volume_in_1m_state_tracker = COALESCE((
-    SELECT volume_base
-    FROM periodic_state_events AS pse
-    WHERE period = 'period_1m' AND pse.market_id = market_latest_state_event.market_id
-    ORDER BY start_time DESC LIMIT 1
-), 0::NUMERIC);
+ADD COLUMN base_volume_in_1m_state_tracker NUMERIC NOT NULL;
 
 -- Calculate the 24h rolling volume for each market.
 CREATE OR REPLACE VIEW market_daily_volume AS

--- a/rust/processor/src/db/postgres/migrations/2025-01-21-033858_add_daily_base_volume_to_user_pools/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-21-033858_add_daily_base_volume_to_user_pools/down.sql
@@ -1,0 +1,60 @@
+-- This file should undo anything in `up.sql`
+DROP FUNCTION user_pools(provider text);
+CREATE FUNCTION user_pools(provider text) RETURNS TABLE(
+  transaction_version BIGINT,
+  sender VARCHAR(66),
+  entry_function VARCHAR(200),
+  transaction_timestamp TIMESTAMP,
+  inserted_at TIMESTAMP,
+
+  -- Market and state metadata.
+  market_id BIGINT,
+  symbol_bytes BYTEA,
+  symbol_emojis TEXT[],
+  bump_time TIMESTAMP, -- Note that bump and emit time are interchangeable.
+  market_nonce BIGINT,
+  trigger trigger_type,
+  market_address VARCHAR(66),
+
+  -- State event data.
+  clamm_virtual_reserves_base BIGINT,
+  clamm_virtual_reserves_quote BIGINT,
+  cpamm_real_reserves_base BIGINT,
+  cpamm_real_reserves_quote BIGINT,
+  lp_coin_supply NUMERIC,
+  cumulative_stats_base_volume NUMERIC,
+  cumulative_stats_quote_volume NUMERIC,
+  cumulative_stats_integrator_fees NUMERIC,
+  cumulative_stats_pool_fees_base NUMERIC,
+  cumulative_stats_pool_fees_quote NUMERIC,
+  cumulative_stats_n_swaps BIGINT,
+  cumulative_stats_n_chat_messages BIGINT,
+  instantaneous_stats_total_quote_locked BIGINT,
+  instantaneous_stats_total_value_locked NUMERIC,
+  instantaneous_stats_market_cap NUMERIC,
+  instantaneous_stats_fully_diluted_value NUMERIC,
+  last_swap_is_sell BOOLEAN,
+  last_swap_avg_execution_price_q64 NUMERIC,
+  last_swap_base_volume BIGINT,
+  last_swap_quote_volume BIGINT,
+  last_swap_nonce BIGINT,
+  last_swap_time TIMESTAMP,
+
+  -- Querying all post-bonding curve markets. i.e., markets with liquidity pools.
+  daily_tvl_per_lp_coin_growth NUMERIC,
+  in_bonding_curve BOOLEAN,
+  volume_in_1m_state_tracker NUMERIC,
+
+  daily_volume NUMERIC,
+
+  lp_coin_balance BIGINT
+)
+AS $$
+SELECT ms.*, ulp.lp_coin_balance
+FROM
+    market_state AS ms,
+    user_liquidity_pools AS ulp
+WHERE ms.market_id = ulp.market_id
+AND ulp.provider = $1
+AND lp_coin_balance <> 0
+$$ LANGUAGE SQL;

--- a/rust/processor/src/db/postgres/migrations/2025-01-21-033858_add_daily_base_volume_to_user_pools/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-21-033858_add_daily_base_volume_to_user_pools/up.sql
@@ -1,0 +1,62 @@
+-- Your SQL goes here
+DROP FUNCTION user_pools(provider text);
+CREATE FUNCTION user_pools(provider text) RETURNS TABLE(
+  transaction_version BIGINT,
+  sender VARCHAR(66),
+  entry_function VARCHAR(200),
+  transaction_timestamp TIMESTAMP,
+  inserted_at TIMESTAMP,
+
+  -- Market and state metadata.
+  market_id BIGINT,
+  symbol_bytes BYTEA,
+  symbol_emojis TEXT[],
+  bump_time TIMESTAMP, -- Note that bump and emit time are interchangeable.
+  market_nonce BIGINT,
+  trigger trigger_type,
+  market_address VARCHAR(66),
+
+  -- State event data.
+  clamm_virtual_reserves_base BIGINT,
+  clamm_virtual_reserves_quote BIGINT,
+  cpamm_real_reserves_base BIGINT,
+  cpamm_real_reserves_quote BIGINT,
+  lp_coin_supply NUMERIC,
+  cumulative_stats_base_volume NUMERIC,
+  cumulative_stats_quote_volume NUMERIC,
+  cumulative_stats_integrator_fees NUMERIC,
+  cumulative_stats_pool_fees_base NUMERIC,
+  cumulative_stats_pool_fees_quote NUMERIC,
+  cumulative_stats_n_swaps BIGINT,
+  cumulative_stats_n_chat_messages BIGINT,
+  instantaneous_stats_total_quote_locked BIGINT,
+  instantaneous_stats_total_value_locked NUMERIC,
+  instantaneous_stats_market_cap NUMERIC,
+  instantaneous_stats_fully_diluted_value NUMERIC,
+  last_swap_is_sell BOOLEAN,
+  last_swap_avg_execution_price_q64 NUMERIC,
+  last_swap_base_volume BIGINT,
+  last_swap_quote_volume BIGINT,
+  last_swap_nonce BIGINT,
+  last_swap_time TIMESTAMP,
+
+  -- Querying all post-bonding curve markets. i.e., markets with liquidity pools.
+  daily_tvl_per_lp_coin_growth NUMERIC,
+  in_bonding_curve BOOLEAN,
+  volume_in_1m_state_tracker NUMERIC,
+  base_volume_in_1m_state_tracker NUMERIC, 
+
+  daily_volume NUMERIC,
+  daily_base_volume NUMERIC,
+
+  lp_coin_balance BIGINT
+)
+AS $$
+SELECT ms.*, ulp.lp_coin_balance
+FROM
+    market_state AS ms,
+    user_liquidity_pools AS ulp
+WHERE ms.market_id = ulp.market_id
+AND ulp.provider = $1
+AND lp_coin_balance <> 0
+$$ LANGUAGE SQL;


### PR DESCRIPTION
# Description

Fix daily base volume fields

- [x] Remove the attempt at backfilling, as this data has to be populated from live on-chain state, and the inclusion of zeroed out fields will actually result in incorrect data, since we use `COALESCE` in a specific way when aggregating the total volume in the 1-min periods
- [x] To reiterate: this data cannot be backfilled
- [x] Add the `base_` field to the `user_pools` function, since it uses `market_state` fields and the return rows do not match the `RETURN TABLE(…)` without the new fields

NOTE: The previous `up.sql` is altered instead of adding an entirely new migration for fixing the insertion/backfilling logic, since we haven't pushed this to AWS yet, it won't require a cold upgrade and this is much cleaner code-wise.