### PR TITLE
[ECO-2695] Fix the unsafe `.unwrap()` call by using the safer matching pattern

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -628,30 +628,22 @@ impl ArenaEvent {
         txn_version: i64,
         event_index: i64,
     ) -> Result<Option<Self>> {
-        let mut data_map: serde_json::Map<String, serde_json::Value> =
-            serde_json::from_str(data).unwrap();
-        let mut event_index_map: serde_json::Map<String, serde_json::Value> =
-            serde_json::from_value(json!({
-                "event_index": event_index.to_string()
-            }))
-            .unwrap();
-        data_map.append(&mut event_index_map);
-        let data_object = serde_json::Value::Object(data_map);
         match EmojicoinTypeTag::from_type_str(event_type) {
             Some(EmojicoinTypeTag::ArenaMelee) => {
-                serde_json::from_value(data_object).map(|inner| Some(Self::Melee(inner)))
+                serde_json::from_str(data).map(|inner| Some(Self::Melee(inner)))
             },
             Some(EmojicoinTypeTag::ArenaEnter) => {
-                serde_json::from_value(data_object).map(|inner| Some(Self::Enter(inner)))
+                serde_json::from_str(data).map(|inner| Some(Self::Enter(inner)))
             },
             Some(EmojicoinTypeTag::ArenaExit) => {
-                serde_json::from_value(data_object).map(|inner| Some(Self::Exit(inner)))
+                serde_json::from_str(data).map(|inner| Some(Self::Exit(inner)))
             },
             Some(EmojicoinTypeTag::ArenaSwap) => {
-                serde_json::from_value(data_object).map(|inner| Some(Self::Swap(inner)))
+                serde_json::from_str(data).map(|inner| Some(Self::Swap(inner)))
             },
-            Some(EmojicoinTypeTag::ArenaVaultBalanceUpdate) => serde_json::from_value(data_object)
-                .map(|inner| Some(Self::VaultBalanceUpdate(inner))),
+            Some(EmojicoinTypeTag::ArenaVaultBalanceUpdate) => {
+                serde_json::from_str(data).map(|inner| Some(Self::VaultBalanceUpdate(inner)))
+            },
             _ => Ok(None),
         }
         .context(format!(

--- a/rust/processor/src/db/postgres/migrations/2025-01-25-223042_add_data_integrity_check_at_txn_version/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-25-223042_add_data_integrity_check_at_txn_version/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DROP FUNCTION aggregate_market_data();

--- a/rust/processor/src/db/postgres/migrations/2025-01-25-223042_add_data_integrity_check_at_txn_version/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-25-223042_add_data_integrity_check_at_txn_version/down.sql
@@ -1,3 +1,3 @@
 -- This file should undo anything in `up.sql`
 
-DROP FUNCTION aggregate_market_data();
+DROP FUNCTION aggregate_market_state();

--- a/rust/processor/src/db/postgres/migrations/2025-01-25-223042_add_data_integrity_check_at_txn_version/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-25-223042_add_data_integrity_check_at_txn_version/up.sql
@@ -1,0 +1,75 @@
+-- Your SQL goes here
+
+-- This function atomically returns the state of all market states at a single
+-- point in time- specifically, when the transaction version is equal to the
+-- `last_success_version` returned.
+--
+-- It's possible to verify the data integrity of the database to some extent
+-- by comparing the values of global on-chain state against these aggregate
+-- values.
+--
+-- Note that the latest global state event data in the database isn't returned here
+-- because it's not the latest global state, it's the latest *emitted* global state.
+--
+-- To verify the data integrity at a specific transaction version, retrieve the
+-- on-chain global state resource where the transaction version specified is the
+-- `last_success_version` that this function returns, and then compare all values.
+CREATE FUNCTION aggregate_market_data() RETURNS TABLE(
+  -- `processor_status` columns at the exact time of the query.
+  last_success_version BIGINT,
+  last_updated TIMESTAMP,
+  last_transaction_timestamp TIMESTAMP,
+
+  -- Aggregate number of markets.
+  num_markets BIGINT,
+  num_markets_in_bonding_curve BIGINT,
+  num_markets_post_bonding_curve BIGINT,
+
+  -- Globally aggregated market state data.
+  aggregate_quote_volume NUMERIC,
+  aggregate_total_quote_locked NUMERIC,
+  aggregate_total_value_locked NUMERIC,
+  aggregate_market_cap NUMERIC,
+  aggregate_fully_diluted_value NUMERIC,
+  aggregate_integrator_fees NUMERIC,
+  aggregate_num_swaps BIGINT,
+  aggregate_num_chat_messages BIGINT,
+  aggregate_market_nonces BIGINT
+)
+AS $$
+WITH aggregate_market_states AS (
+    SELECT
+        COUNT(*) as num_markets,
+        COUNT(*) FILTER (WHERE in_bonding_curve = true) as num_markets_in_bonding_curve,
+        COUNT(*) FILTER (WHERE in_bonding_curve = false) as num_markets_post_bonding_curve,
+        SUM(cumulative_stats_quote_volume) as aggregate_quote_volume,
+        SUM(instantaneous_stats_total_quote_locked) as aggregate_total_quote_locked,
+        SUM(instantaneous_stats_total_value_locked) as aggregate_total_value_locked,
+        SUM(instantaneous_stats_market_cap) as aggregate_market_cap,
+        SUM(instantaneous_stats_fully_diluted_value) as aggregate_fully_diluted_value,
+        SUM(cumulative_stats_integrator_fees) as aggregate_integrator_fees,
+        SUM(cumulative_stats_n_swaps) as aggregate_num_swaps,
+        SUM(cumulative_stats_n_chat_messages) as aggregate_num_chat_messages,
+        SUM(market_nonce) as aggregate_market_nonces
+    FROM market_state
+)
+SELECT
+    ps.last_success_version,
+    ps.last_updated,
+    ps.last_transaction_timestamp,
+    agg_ms.num_markets,
+    agg_ms.num_markets_in_bonding_curve,
+    agg_ms.num_markets_post_bonding_curve,
+    agg_ms.aggregate_quote_volume,
+    agg_ms.aggregate_total_quote_locked,
+    agg_ms.aggregate_total_value_locked,
+    agg_ms.aggregate_market_cap,
+    agg_ms.aggregate_fully_diluted_value,
+    agg_ms.aggregate_integrator_fees,
+    agg_ms.aggregate_num_swaps,
+    agg_ms.aggregate_num_chat_messages,
+    agg_ms.aggregate_market_nonces
+FROM
+    processor_status as ps,
+    aggregate_market_states as agg_ms;
+$$ LANGUAGE SQL;

--- a/rust/processor/src/db/postgres/migrations/2025-01-25-223042_add_data_integrity_check_at_txn_version/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-25-223042_add_data_integrity_check_at_txn_version/up.sql
@@ -2,7 +2,7 @@
 
 -- This function atomically returns the state of all market states at a single
 -- point in time- specifically, when the transaction version is equal to the
--- `last_success_version` returned.
+-- `last_emojicoin_transaction_version` returned.
 --
 -- It's possible to verify the data integrity of the database to some extent
 -- by comparing the values of global on-chain state against these aggregate
@@ -13,63 +13,53 @@
 --
 -- To verify the data integrity at a specific transaction version, retrieve the
 -- on-chain global state resource where the transaction version specified is the
--- `last_success_version` that this function returns, and then compare all values.
-CREATE FUNCTION aggregate_market_data() RETURNS TABLE(
-  -- `processor_status` columns at the exact time of the query.
-  last_success_version BIGINT,
-  last_updated TIMESTAMP,
-  last_transaction_timestamp TIMESTAMP,
+-- `last_emojicoin_transaction_version` that this function returns, and then compare
+-- all values.
+--
+-- NOTE: `last_success_version` from the `processor_status` is not synced with
+-- new event data inserted and can actually be behind the highest emojicoin
+-- transaction version. To properly get the last successfully processed and inserted
+-- emojicoin version, it's necessary to get the max transaction version among
+-- all transaction versions.
+CREATE FUNCTION aggregate_market_state() RETURNS TABLE(
+  last_emojicoin_transaction_version BIGINT,
 
-  -- Aggregate number of markets.
-  num_markets BIGINT,
-  num_markets_in_bonding_curve BIGINT,
-  num_markets_post_bonding_curve BIGINT,
-
-  -- Globally aggregated market state data.
-  aggregate_quote_volume NUMERIC,
-  aggregate_total_quote_locked NUMERIC,
-  aggregate_total_value_locked NUMERIC,
-  aggregate_market_cap NUMERIC,
-  aggregate_fully_diluted_value NUMERIC,
-  aggregate_integrator_fees NUMERIC,
-  aggregate_num_swaps BIGINT,
-  aggregate_num_chat_messages BIGINT,
-  aggregate_market_nonces BIGINT
+  -- The following columns are structured to match all the `registry_view` fields.
+  cumulative_chat_messages BIGINT,
+  cumulative_integrator_fees NUMERIC,
+  cumulative_quote_volume NUMERIC,
+  cumulative_swaps BIGINT,
+  fully_diluted_value NUMERIC,
+  last_bump_time TIMESTAMP,
+  market_cap NUMERIC,
+  n_markets BIGINT,
+  nonce BIGINT,
+  total_quote_locked NUMERIC,
+  total_value_locked NUMERIC,
+  
+  n_markets_in_bonding_curve BIGINT,
+  n_markets_post_bonding_curve BIGINT
 )
 AS $$
-WITH aggregate_market_states AS (
-    SELECT
-        COUNT(*) as num_markets,
-        COUNT(*) FILTER (WHERE in_bonding_curve = true) as num_markets_in_bonding_curve,
-        COUNT(*) FILTER (WHERE in_bonding_curve = false) as num_markets_post_bonding_curve,
-        SUM(cumulative_stats_quote_volume) as aggregate_quote_volume,
-        SUM(instantaneous_stats_total_quote_locked) as aggregate_total_quote_locked,
-        SUM(instantaneous_stats_total_value_locked) as aggregate_total_value_locked,
-        SUM(instantaneous_stats_market_cap) as aggregate_market_cap,
-        SUM(instantaneous_stats_fully_diluted_value) as aggregate_fully_diluted_value,
-        SUM(cumulative_stats_integrator_fees) as aggregate_integrator_fees,
-        SUM(cumulative_stats_n_swaps) as aggregate_num_swaps,
-        SUM(cumulative_stats_n_chat_messages) as aggregate_num_chat_messages,
-        SUM(market_nonce) as aggregate_market_nonces
-    FROM market_state
-)
 SELECT
-    ps.last_success_version,
-    ps.last_updated,
-    ps.last_transaction_timestamp,
-    agg_ms.num_markets,
-    agg_ms.num_markets_in_bonding_curve,
-    agg_ms.num_markets_post_bonding_curve,
-    agg_ms.aggregate_quote_volume,
-    agg_ms.aggregate_total_quote_locked,
-    agg_ms.aggregate_total_value_locked,
-    agg_ms.aggregate_market_cap,
-    agg_ms.aggregate_fully_diluted_value,
-    agg_ms.aggregate_integrator_fees,
-    agg_ms.aggregate_num_swaps,
-    agg_ms.aggregate_num_chat_messages,
-    agg_ms.aggregate_market_nonces
-FROM
-    processor_status as ps,
-    aggregate_market_states as agg_ms;
+    MAX(transaction_version) as last_emojicoin_transaction_version,
+
+    -- The following columns mirror the `registry_view` return value structure.
+    SUM(cumulative_stats_n_chat_messages) as cumulative_chat_messages,
+    SUM(cumulative_stats_integrator_fees) as cumulative_integrator_fees,
+    SUM(cumulative_stats_quote_volume) as cumulative_quote_volume,
+    SUM(cumulative_stats_n_swaps) as cumulative_swaps,
+    SUM(instantaneous_stats_fully_diluted_value) as fully_diluted_value,
+    MAX(bump_time) as last_bump_time, 
+    SUM(instantaneous_stats_market_cap) as market_cap,
+    COUNT(*) as n_markets,
+    -- Add one to account for `init_module` incrementing the registry nonce without
+    -- incrementing a market's `market_nonce`.
+    SUM(market_nonce) + 1 as nonce,
+    SUM(instantaneous_stats_total_quote_locked) as total_quote_locked,
+    SUM(instantaneous_stats_total_value_locked) as total_value_locked,
+
+    COUNT(*) FILTER (WHERE in_bonding_curve = true) as n_markets_in_bonding_curve,
+    COUNT(*) FILTER (WHERE in_bonding_curve = false) as n_markets_post_bonding_curve
+FROM market_state
 $$ LANGUAGE SQL;

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -360,11 +360,12 @@ impl ProcessorTrait for EmojicoinProcessor {
 
                 // Group the market events in this transaction.
                 let mut market_events = vec![];
-                let mut arena_events = vec![];
                 for (event_index, event) in user_txn.events.iter().enumerate() {
                     let type_str = event.type_str.as_str();
                     let data = event.data.as_str();
 
+                    
+                    // Check if it's a basic emojicoin_dot_fun event with a market.
                     match EventWithMarket::from_event_type(
                         type_str,
                         data,
@@ -379,21 +380,39 @@ impl ProcessorTrait for EmojicoinProcessor {
                                 period_data.push(one_min_pse);
                             }
                         },
+                        // Otherwise, it's an arena event or a global state event.
                         _ => {
-                            if let Some(global_event) =
+                            if let Some(evt) = ArenaEvent::from_event_type(
+                                type_str,
+                                data,
+                                txn_version,
+                                event_index as i64,
+                            )? {
+                                match evt {
+                                    ArenaEvent::Melee(melee) => arena_melee_events_db
+                                        .push(ArenaMeleeEventModel::new(txn_info.clone(), melee)),
+                                    ArenaEvent::Enter(enter) => arena_enter_events_db
+                                        .push(ArenaEnterEventModel::new(txn_info.clone(), enter)),
+                                    ArenaEvent::Exit(exit) => arena_exit_events_db
+                                        .push(ArenaExitEventModel::new(txn_info.clone(), exit)),
+                                    ArenaEvent::Swap(swap) => arena_swap_events_db
+                                        .push(ArenaSwapEventModel::new(txn_info.clone(), swap)),
+                                    ArenaEvent::VaultBalanceUpdate(vault_balance_update) => {
+                                        arena_vault_balance_update_events_db.push(
+                                            ArenaVaultBalanceUpdateEventModel::new(
+                                                txn_info.clone(),
+                                                vault_balance_update,
+                                            ),
+                                        )
+                                    },
+                                }
+                            } else if let Some(global_event) =
                                 GlobalStateEvent::from_event_type(type_str, data, txn_version)?
                             {
                                 global_state_events_db.push(GlobalStateEventModel::new(
                                     txn_info.clone(),
                                     global_event,
                                 ));
-                            } else if let Some(evt) = ArenaEvent::from_event_type(
-                                type_str,
-                                data,
-                                txn_version,
-                                event_index as i64,
-                            )? {
-                                arena_events.push(evt.clone());
                             }
                         },
                     }
@@ -513,26 +532,6 @@ impl ProcessorTrait for EmojicoinProcessor {
                                     }
                                 })
                                 .or_insert(new_pool);
-                        },
-                    }
-                }
-                for event in arena_events {
-                    match event {
-                        ArenaEvent::Melee(melee) => arena_melee_events_db
-                            .push(ArenaMeleeEventModel::new(txn_info.clone(), melee)),
-                        ArenaEvent::Enter(enter) => arena_enter_events_db
-                            .push(ArenaEnterEventModel::new(txn_info.clone(), enter)),
-                        ArenaEvent::Exit(exit) => arena_exit_events_db
-                            .push(ArenaExitEventModel::new(txn_info.clone(), exit)),
-                        ArenaEvent::Swap(swap) => arena_swap_events_db
-                            .push(ArenaSwapEventModel::new(txn_info.clone(), swap)),
-                        ArenaEvent::VaultBalanceUpdate(vault_balance_update) => {
-                            arena_vault_balance_update_events_db.push(
-                                ArenaVaultBalanceUpdateEventModel::new(
-                                    txn_info.clone(),
-                                    vault_balance_update,
-                                ),
-                            )
                         },
                     }
                 }

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::common::models::emojicoin_models::{
-        enums::Trigger,
+        enums::{EmojicoinTypeTag, Trigger},
         event_utils::EventGroupBuilder,
         json_types::{
             ArenaEvent, BumpEvent, EventGroup, EventWithMarket, GlobalStateEvent,
@@ -364,57 +364,55 @@ impl ProcessorTrait for EmojicoinProcessor {
                     let type_str = event.type_str.as_str();
                     let data = event.data.as_str();
 
-                    
-                    // Check if it's a basic emojicoin_dot_fun event with a market.
-                    match EventWithMarket::from_event_type(
-                        type_str,
-                        data,
-                        txn_version,
-                        event_index as i64,
-                    )? {
-                        Some(evt) => {
+                    // Only parse events that match an `EmojicoinTypeTag`. This protects against
+                    // parsing invalid or unexpected JSON data.
+                    if EmojicoinTypeTag::from_type_str(type_str).is_some() {
+                        // If it's an event with a market, parse it and add it to `market_events`
+                        // and possibly the one minute periodic state events.
+                        if let Some(evt) = EventWithMarket::from_event_type(
+                            type_str,
+                            data,
+                            txn_version,
+                            event_index as i64,
+                        )? {
                             market_events.push(evt.clone());
                             if let Some(one_min_pse) =
                                 RecentOneMinutePeriodicStateEvent::try_from_event(evt, txn_version)
                             {
                                 period_data.push(one_min_pse);
                             }
-                        },
-                        // Otherwise, it's an arena event or a global state event.
-                        _ => {
-                            if let Some(evt) = ArenaEvent::from_event_type(
-                                type_str,
-                                data,
-                                txn_version,
-                                event_index as i64,
-                            )? {
-                                match evt {
-                                    ArenaEvent::Melee(melee) => arena_melee_events_db
-                                        .push(ArenaMeleeEventModel::new(txn_info.clone(), melee)),
-                                    ArenaEvent::Enter(enter) => arena_enter_events_db
-                                        .push(ArenaEnterEventModel::new(txn_info.clone(), enter)),
-                                    ArenaEvent::Exit(exit) => arena_exit_events_db
-                                        .push(ArenaExitEventModel::new(txn_info.clone(), exit)),
-                                    ArenaEvent::Swap(swap) => arena_swap_events_db
-                                        .push(ArenaSwapEventModel::new(txn_info.clone(), swap)),
-                                    ArenaEvent::VaultBalanceUpdate(vault_balance_update) => {
-                                        arena_vault_balance_update_events_db.push(
-                                            ArenaVaultBalanceUpdateEventModel::new(
-                                                txn_info.clone(),
-                                                vault_balance_update,
-                                            ),
-                                        )
-                                    },
-                                }
-                            } else if let Some(global_event) =
-                                GlobalStateEvent::from_event_type(type_str, data, txn_version)?
-                            {
-                                global_state_events_db.push(GlobalStateEventModel::new(
-                                    txn_info.clone(),
-                                    global_event,
-                                ));
+                        // If it's an arena event, parse it and add it to the proper arena events vector.
+                        } else if let Some(evt) = ArenaEvent::from_event_type(
+                            type_str,
+                            data,
+                            txn_version,
+                            event_index as i64,
+                        )? {
+                            match evt {
+                                ArenaEvent::Melee(melee) => arena_melee_events_db
+                                    .push(ArenaMeleeEventModel::new(txn_info.clone(), melee)),
+                                ArenaEvent::Enter(enter) => arena_enter_events_db
+                                    .push(ArenaEnterEventModel::new(txn_info.clone(), enter)),
+                                ArenaEvent::Exit(exit) => arena_exit_events_db
+                                    .push(ArenaExitEventModel::new(txn_info.clone(), exit)),
+                                ArenaEvent::Swap(swap) => arena_swap_events_db
+                                    .push(ArenaSwapEventModel::new(txn_info.clone(), swap)),
+                                ArenaEvent::VaultBalanceUpdate(vault_balance_update) => {
+                                    arena_vault_balance_update_events_db.push(
+                                        ArenaVaultBalanceUpdateEventModel::new(
+                                            txn_info.clone(),
+                                            vault_balance_update,
+                                        ),
+                                    )
+                                },
                             }
-                        },
+                        // If it's a global state event, parse and add it to the global state events vector.
+                        } else if let Some(global_event) =
+                            GlobalStateEvent::from_event_type(type_str, data, txn_version)?
+                        {
+                            global_state_events_db
+                                .push(GlobalStateEventModel::new(txn_info.clone(), global_event));
+                        }
                     }
                 }
 


### PR DESCRIPTION
# Description

The matching/parsing flow for the newer arena events didn't follow the same parsing logic and code flow as the previous parsing logic (for emojicoin events).

I've converted the flow to the previous, "battle-hardened" code flow, which also avoids the unsafe unwrap.

- [x] Fix the unsafe unwrap issue
- [x] Ensure that unsafe event_types are properly ignored and never unwrapped, by matching on the event type string before calling `serde` parsing functions
- [x] Ensure there are no assumptions about the incoming event type struct strings, package addresses, etc

# Testing

- [x] Backfill `mainnet` up to chain tip and ensure there are no parsing errors
- [x] In particular, ensure that the processor gets past version 1977033592

Once backfilled the latest transaction version, use it to verify against the indexer db data:

- [x] Ensure # of swap events matches # of swap events on-chain
- [x] Ensure # of market registration events matches # on-chain
- [x] Ensure # of chat events matches # on-chain
- [x] Ensure # of liquidity events matches # on-chain
- [x] Ensure # of global state events matches # on-chain
- [x] Ensure all nonces are equal

For the above, see #74 
