### PR TITLE
[ECO-2711] Fix processor's `market_state`'s `instantaneous_stats` and `trigger` logic for multi-event transactions

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -625,7 +625,7 @@ impl ArenaEvent {
         event_type: &str,
         data: &str,
         txn_version: i64,
-        _event_index: i64,
+        event_index: i64,
     ) -> Result<Option<Self>> {
         match EmojicoinTypeTag::from_type_str(event_type) {
             Some(EmojicoinTypeTag::ArenaMelee) => {

--- a/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -13,6 +13,7 @@ use anyhow::{Context, Result};
 use aptos_protos::transaction::v1::WriteResource;
 use bigdecimal::BigDecimal;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::json;
 use std::str::FromStr;
 
 pub fn serialize_bytes_to_hex_string<S>(element: &Vec<u8>, s: S) -> Result<S::Ok, S::Error>

--- a/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -13,7 +13,6 @@ use anyhow::{Context, Result};
 use aptos_protos::transaction::v1::WriteResource;
 use bigdecimal::BigDecimal;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::json;
 use std::str::FromStr;
 
 pub fn serialize_bytes_to_hex_string<S>(element: &Vec<u8>, s: S) -> Result<S::Ok, S::Error>
@@ -626,7 +625,7 @@ impl ArenaEvent {
         event_type: &str,
         data: &str,
         txn_version: i64,
-        event_index: i64,
+        _event_index: i64,
     ) -> Result<Option<Self>> {
         match EmojicoinTypeTag::from_type_str(event_type) {
             Some(EmojicoinTypeTag::ArenaMelee) => {

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -452,6 +452,18 @@ impl ProcessorTrait for EmojicoinProcessor {
 
                     let market_addr = &state_event.market_metadata.market_address;
 
+                    // A market resource in a transaction changeset will *always* contain the latest
+                    // market state for that transaction by virtue of the writeset reflecting the
+                    // final state of the market at the end of the transaction.
+                    //
+                    // Thus, the boolean condition to enter the `and_modify` code block below must
+                    // use `<=` to ensure that in the case where the event with a lower nonce is
+                    // inserted into the hashmap with `or_insert_with` first, the `latest_trigger`
+                    // and `latest_instant_stats` are still properly updated.
+                    //
+                    // These comparisons remove the need to parse the writeset for every single
+                    // event and instead only parse it for events that are newer than what's
+                    // currently in the hashamp for that market.
                     latest_market_resources
                         .entry(market_id)
                         .and_modify(
@@ -461,7 +473,7 @@ impl ProcessorTrait for EmojicoinProcessor {
                                 latest_trigger,
                                 latest_instant_stats,
                             )| {
-                                if latest_resource.sequence_info.nonce < market_nonce {
+                                if latest_resource.sequence_info.nonce <= market_nonce {
                                     // Writeset changes reflect the final state changes from the transaction; same version == same changes.
                                     if txn_info_for_latest.version != txn_version {
                                         *latest_resource = MarketResource::from_write_set_changes(


### PR DESCRIPTION
# Description

The logic for processing events that occurred in the same transaction would result in only the first event processed's `instantaneous_stats_*` and `trigger` being used in the final market state. This is obviously incorrect, since the first event processed will possibly not have the latest instantaneous stats.

I noticed this when running the verify processor data checks and saw that the instantaneous stats were slightly off. Once I diagnosed the exact cause by looking at the offending market and market nonce, I saw that it was due to a multi-event transaction, specifically two offenders:

```typescript
{
  transaction_version: [ '2237249514', '2237249514', true ],
  market_id: [ '1556', '1556', true ],
  symbol_emojis: [ '🐶,🆗', '🐶,🆗', true ],
  market_nonce: [ '281', '281', true ],
  instantaneous_stats_total_quote_locked: [ '417576661', '412798878', false ],
  instantaneous_stats_total_value_locked: [ '37501315562', '37492548139', false ],
  instantaneous_stats_market_cap: [ '421935894', '417058927', false ],
  instantaneous_stats_fully_diluted_value: [ '37505674796', '37496808188', false ]
}
{
  transaction_version: [ '2263371973', '2263371973', true ],
  market_id: [ '1973', '1973', true ],
  symbol_emojis: [ '🌐,🌊', '🌐,🌊', true ],
  market_nonce: [ '102', '102', true ],
  instantaneous_stats_total_quote_locked: [ '4309591142', '4309383459', false ],
  instantaneous_stats_total_value_locked: [ '44612366230', '44611988424', false ],
  instantaneous_stats_market_cap: [ '4773905517', '4773653083', false ],
  instantaneous_stats_fully_diluted_value: [ '45076680605', '45076258049', false ]
}
```

in the instantaneous stats values (first value in each array is what's in the database, the second is what's on-chain, that is, instantaneous `total_quote_locked` for `market_id = 1556` is `417576661` in the database, but `412798878` on-chain.

When I looked at the database data, I saw that the individual values for market nonce 280 and 281 were both correct, but the `market_state` table reflected the `instantaneous_stats` for `market_nonce` `280`, not `281`, but the rest of the `market_state` reflected `market_nonce` `281`.

See here:

```sql
emojicoin=# SELECT * FROM swap_events WHERE market_id = 1556 AND market_nonce = 281;
-[ RECORD 1 ]----------------------------------------+----------------------------------------------------------------------------------------------
transaction_version                                  | 2237249514
sender                                               | 0x761ce760db376d1aa666443305bc0a70e4ea876713d03e130349c7b4ddfce863
entry_function                                       | 0x1c3206329806286fd2223647c9f9b130e66baeb6d7224a18c1f642ffe48f3b4c::panora_swap::router_entry
transaction_timestamp                                | 2025-01-21 21:38:51.963689
inserted_at                                          | 2025-01-27 02:01:27.646898
market_id                                            | 1556
symbol_bytes                                         | \xf09f90b6f09f8697
symbol_emojis                                        | {🐶,🆗}
bump_time                                            | 2025-01-21 21:38:51.963689
market_nonce                                         | 281
trigger                                              | swap_sell
market_address                                       | 0x98772c402ba3b6d79174a5bdf9096e807a314867e5a40a4094f404d7d3066b18
swapper                                              | 0xb7cb159db88215cd1670edfe4e30df58177571610983fc06681f4c9773810b3e
integrator                                           | 0xd0b17bea776bb87b70b2fb2ca631014f0ca94fc1acde4b8ff1a763f4172aa6c4
integrator_fee                                       | 47777
input_amount                                         | 573315039081
is_sell                                              | t
integrator_fee_rate_bps                              | 100
net_proceeds                                         | 4730006
base_volume                                          | 573315039081
quote_volume                                         | 4730006
avg_execution_price_q64                              | 152190687844110
pool_fee                                             | 0
starts_in_bonding_curve                              | t
results_in_state_transition                          | f
clamm_virtual_reserves_base                          | 4849948668590695
clamm_virtual_reserves_quote                         | 40412798878
cpamm_real_reserves_base                             | 0
cpamm_real_reserves_quote                            | 0
lp_coin_supply                                       | 0
cumulative_stats_base_volume                         | 6608036867929971
cumulative_stats_quote_volume                        | 167995770028
cumulative_stats_integrator_fees                     | 1796926905
cumulative_stats_pool_fees_base                      | 0
cumulative_stats_pool_fees_quote                     | 0
cumulative_stats_n_swaps                             | 280
cumulative_stats_n_chat_messages                     | 0
instantaneous_stats_total_quote_locked               | 412798878
instantaneous_stats_total_value_locked               | 37492548139
instantaneous_stats_market_cap                       | 417058927
instantaneous_stats_fully_diluted_value              | 37496808188
balance_as_fraction_of_circulating_supply_before_q64 | 208906067330632609
balance_as_fraction_of_circulating_supply_after_q64  | 0
block_number                                         | 280175466
event_index                                          | 24

emojicoin=# SELECT * FROM swap_events WHERE market_id = 1556 AND market_nonce = 280;
-[ RECORD 1 ]----------------------------------------+----------------------------------------------------------------------------------------------
transaction_version                                  | 2237249514
sender                                               | 0x761ce760db376d1aa666443305bc0a70e4ea876713d03e130349c7b4ddfce863
entry_function                                       | 0x1c3206329806286fd2223647c9f9b130e66baeb6d7224a18c1f642ffe48f3b4c::panora_swap::router_entry
transaction_timestamp                                | 2025-01-21 21:38:51.963689
inserted_at                                          | 2025-01-27 02:01:27.646898
market_id                                            | 1556
symbol_bytes                                         | \xf09f90b6f09f8697
symbol_emojis                                        | {🐶,🆗}
bump_time                                            | 2025-01-21 21:38:51.963689
market_nonce                                         | 280
trigger                                              | swap_sell
market_address                                       | 0x98772c402ba3b6d79174a5bdf9096e807a314867e5a40a4094f404d7d3066b18
swapper                                              | 0xb7cb159db88215cd1670edfe4e30df58177571610983fc06681f4c9773810b3e
integrator                                           | 0xd0b17bea776bb87b70b2fb2ca631014f0ca94fc1acde4b8ff1a763f4172aa6c4
integrator_fee                                       | 1150066
input_amount                                         | 13759560937925
is_sell                                              | t
integrator_fee_rate_bps                              | 100
net_proceeds                                         | 113856612
base_volume                                          | 13759560937925
quote_volume                                         | 113856612
avg_execution_price_q64                              | 152641773392253
pool_fee                                             | 0
starts_in_bonding_curve                              | t
results_in_state_transition                          | f
clamm_virtual_reserves_base                          | 4849375353551614
clamm_virtual_reserves_quote                         | 40417576661
cpamm_real_reserves_base                             | 0
cpamm_real_reserves_quote                            | 0
lp_coin_supply                                       | 0
cumulative_stats_base_volume                         | 6607463552890890
cumulative_stats_quote_volume                        | 167991040022
cumulative_stats_integrator_fees                     | 1796879128
cumulative_stats_pool_fees_base                      | 0
cumulative_stats_pool_fees_quote                     | 0
cumulative_stats_n_swaps                             | 279
cumulative_stats_n_chat_messages                     | 0
instantaneous_stats_total_quote_locked               | 417576661
instantaneous_stats_total_value_locked               | 37501315562
instantaneous_stats_market_cap                       | 421935894
instantaneous_stats_fully_diluted_value              | 37505674796
balance_as_fraction_of_circulating_supply_before_q64 | 3942257107640949089
balance_as_fraction_of_circulating_supply_after_q64  | 0
block_number                                         | 280175466
event_index                                          | 14
```

# Testing

I started a newly built processor starting at version 2237249000 (right before the transaction) with both `<` and `<=` and no other data.

With `<` it didn't insert the stats correctly. With `<=` it properly inserts the newest stats, regardless of the multi-event transaction.

## Notes

Should probably just have parsed the writeset regardless and avoided the more complex insertion/update hashmap code.

Also note this will *NOT* fix existing incorrect values, although there are only 2 markets with incorrect `instantaneous_stats` currently, and they would be fixed permanently as soon as someone interacts with those markets.