### PR TITLE
[ECO-2723] Undo the removal of `NUMERIC` casts in pnl calculation

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2025-01-25-223042_add_data_integrity_check_at_txn_version/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-25-223042_add_data_integrity_check_at_txn_version/up.sql
@@ -59,7 +59,7 @@ WITH agg_ms AS (
       SUM(cumulative_stats_quote_volume) AS cumulative_quote_volume,
       SUM(cumulative_stats_n_swaps) AS cumulative_swaps,
       SUM(instantaneous_stats_fully_diluted_value) AS fully_diluted_value,
-      -- Note this is msot recent market state event bump time,
+      -- Note this is most recent market state event bump time,
       -- not the last `global_state_event.bump_time`.
       MAX(bump_time) AS last_bump_time, 
       SUM(instantaneous_stats_market_cap) AS market_cap,

--- a/rust/processor/src/db/postgres/migrations/2025-01-25-223042_add_data_integrity_check_at_txn_version/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-25-223042_add_data_integrity_check_at_txn_version/up.sql
@@ -30,6 +30,8 @@ CREATE FUNCTION aggregate_market_state() RETURNS TABLE(
   cumulative_quote_volume NUMERIC,
   cumulative_swaps NUMERIC,
   fully_diluted_value NUMERIC,
+  -- Note this is the last `global_state_event.bump_time`,
+  -- not the most recent market state event bump time.
   last_bump_time TIMESTAMP,
   market_cap NUMERIC,
   n_markets NUMERIC,
@@ -57,6 +59,8 @@ WITH agg_ms AS (
       SUM(cumulative_stats_quote_volume) AS cumulative_quote_volume,
       SUM(cumulative_stats_n_swaps) AS cumulative_swaps,
       SUM(instantaneous_stats_fully_diluted_value) AS fully_diluted_value,
+      -- Note this is msot recent market state event bump time,
+      -- not the last `global_state_event.bump_time`.
       MAX(bump_time) AS last_bump_time, 
       SUM(instantaneous_stats_market_cap) AS market_cap,
       COUNT(*) AS n_markets,

--- a/rust/processor/src/db/postgres/migrations/2025-01-29-211732_fix_arena_leaderboard_view_types/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-29-211732_fix_arena_leaderboard_view_types/down.sql
@@ -1,0 +1,35 @@
+-- This file should undo anything in `up.sql`
+
+DROP VIEW arena_leaderboard;
+
+-- This is the original `arena_leaderboard` view as created in `2025-01-08-171729_emojicoin_arena/up.sql`.
+CREATE VIEW arena_leaderboard AS
+WITH melee AS (
+    SELECT * FROM arena_melee_events ORDER BY melee_id DESC LIMIT 1
+), price_emojicoin_0 AS (
+    SELECT avg_execution_price_q64 / POW(2,64) AS price FROM swap_events
+    WHERE market_address = (SELECT emojicoin_0_market_address FROM arena_melee_events WHERE melee_id = (SELECT melee_id FROM melee))
+    ORDER BY market_nonce DESC
+    LIMIT 1
+), price_emojicoin_1 AS (
+    SELECT avg_execution_price_q64 / POW(2,64) AS price FROM swap_events
+    WHERE market_address = (SELECT emojicoin_1_market_address FROM arena_melee_events WHERE melee_id = (SELECT melee_id FROM melee))
+    ORDER BY market_nonce DESC
+    LIMIT 1
+), realized_position AS (
+    SELECT
+        "user",
+        open,
+        emojicoin_0_balance,
+        emojicoin_1_balance,
+        withdrawals +
+            emojicoin_0_balance * (SELECT * FROM price_emojicoin_0) +
+            emojicoin_1_balance * (SELECT * FROM price_emojicoin_1) AS profits,
+        deposits AS losses
+    FROM arena_positions WHERE melee_id = (SELECT melee_id FROM melee)
+)
+SELECT
+    *,
+    profits / losses * 100 - 100 AS pnl_percent,
+    profits - losses AS pnl_octas
+FROM realized_position;

--- a/rust/processor/src/db/postgres/migrations/2025-01-29-211732_fix_arena_leaderboard_view_types/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-29-211732_fix_arena_leaderboard_view_types/up.sql
@@ -1,0 +1,35 @@
+-- Your SQL goes here
+
+DROP VIEW arena_leaderboard;
+
+-- The only changes here are the casts for POW(2,64) to NUMERIC (they previously weren't casted).
+CREATE VIEW arena_leaderboard AS
+WITH melee AS (
+    SELECT * FROM arena_melee_events ORDER BY melee_id DESC LIMIT 1
+), price_emojicoin_0 AS (
+    SELECT avg_execution_price_q64 / POW(2,64)::NUMERIC AS price FROM swap_events
+    WHERE market_address = (SELECT emojicoin_0_market_address FROM arena_melee_events WHERE melee_id = (SELECT melee_id FROM melee))
+    ORDER BY market_nonce DESC
+    LIMIT 1
+), price_emojicoin_1 AS (
+    SELECT avg_execution_price_q64 / POW(2,64)::NUMERIC AS price FROM swap_events
+    WHERE market_address = (SELECT emojicoin_1_market_address FROM arena_melee_events WHERE melee_id = (SELECT melee_id FROM melee))
+    ORDER BY market_nonce DESC
+    LIMIT 1
+), realized_position AS (
+    SELECT
+        "user",
+        open,
+        emojicoin_0_balance,
+        emojicoin_1_balance,
+        withdrawals +
+            emojicoin_0_balance * (SELECT * FROM price_emojicoin_0) +
+            emojicoin_1_balance * (SELECT * FROM price_emojicoin_1) AS profits,
+        deposits AS losses
+    FROM arena_positions WHERE melee_id = (SELECT melee_id FROM melee)
+)
+SELECT
+    *,
+    profits / losses * 100 - 100 AS pnl_percent,
+    profits - losses AS pnl_octas
+FROM realized_position;

--- a/rust/processor/src/db/postgres/migrations/2025-01-29-211732_fix_arena_leaderboard_view_types/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-29-211732_fix_arena_leaderboard_view_types/up.sql
@@ -7,11 +7,13 @@ CREATE VIEW arena_leaderboard AS
 WITH melee AS (
     SELECT * FROM arena_melee_events ORDER BY melee_id DESC LIMIT 1
 ), price_emojicoin_0 AS (
+    --                               Cast change below.
     SELECT avg_execution_price_q64 / POW(2,64)::NUMERIC AS price FROM swap_events
     WHERE market_address = (SELECT emojicoin_0_market_address FROM arena_melee_events WHERE melee_id = (SELECT melee_id FROM melee))
     ORDER BY market_nonce DESC
     LIMIT 1
 ), price_emojicoin_1 AS (
+    --                               Cast change below.
     SELECT avg_execution_price_q64 / POW(2,64)::NUMERIC AS price FROM swap_events
     WHERE market_address = (SELECT emojicoin_1_market_address FROM arena_melee_events WHERE melee_id = (SELECT melee_id FROM melee))
     ORDER BY market_nonce DESC


### PR DESCRIPTION
# Undo the accidental removal of `NUMERIC` casts in pnl calculation

When converting all types to `NUMERIC`, I inadvertently removed the cast to `NUMERIC` thinking it would only affect the comparison between the first division calculation.

It actually affects the view column types, so we need to keep it in.

- [x] Revert that change in a migration, so we don't have to do a cold upgrade