### PR TITLE
[ECO-2730] Add redundant columns to optimize frontend queries

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/down.sql
@@ -4,3 +4,45 @@ ALTER TABLE arena_info DROP COLUMN emojicoin_0_symbols;
 ALTER TABLE arena_info DROP COLUMN emojicoin_1_symbols;
 ALTER TABLE arena_info DROP COLUMN emojicoin_0_market_id;
 ALTER TABLE arena_info DROP COLUMN emojicoin_1_market_id;
+
+CREATE OR REPLACE FUNCTION create_melee_info() RETURNS trigger AS $$
+    BEGIN
+        INSERT INTO arena_info (
+            melee_id,
+            volume,
+            rewards_remaining,
+            apt_locked,
+            emojicoin_0_market_address,
+            emojicoin_1_market_address,
+            start_time,
+            duration,
+            max_match_percentage,
+            max_match_amount
+        ) VALUES (
+            NEW.melee_id,
+            0,
+            NEW.available_rewards,
+            0,
+            NEW.emojicoin_0_market_address,
+            NEW.emojicoin_1_market_address,
+            NEW.start_time,
+            NEW.duration,
+            NEW.max_match_percentage,
+            NEW.max_match_amount
+        )
+        ON CONFLICT (melee_id) DO
+        UPDATE SET
+            rewards_remaining = arena_info.rewards_remaining + NEW.available_rewards,
+            emojicoin_0_market_address = NEW.emojicoin_0_market_address,
+            emojicoin_1_market_address = NEW.emojicoin_1_market_address,
+            start_time = NEW.start_time,
+            duration = NEW.duration,
+            max_match_percentage = NEW.max_match_percentage,
+            max_match_amount = NEW.max_match_amount
+        WHERE arena_info.melee_id = NEW.melee_id;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER create_melee_info_trigger AFTER INSERT ON arena_melee_events
+    FOR EACH ROW EXECUTE FUNCTION create_melee_info();

--- a/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+DROP FUNCTION arena_leaderboard_history_with_arena_info;
+ALTER TABLE arena_info DROP COLUMN emojicoin_0_symbols;
+ALTER TABLE arena_info DROP COLUMN emojicoin_1_symbols;
+ALTER TABLE arena_info DROP COLUMN emojicoin_0_market_id;
+ALTER TABLE arena_info DROP COLUMN emojicoin_1_market_id;

--- a/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/down.sql
@@ -46,3 +46,48 @@ $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE TRIGGER create_melee_info_trigger AFTER INSERT ON arena_melee_events
     FOR EACH ROW EXECUTE FUNCTION create_melee_info();
+
+
+ALTER TABLE arena_leaderboard_history DROP COLUMN last_exit;
+ALTER TABLE arena_leaderboard_history DROP COLUMN emojicoin_0_balance;
+ALTER TABLE arena_leaderboard_history DROP COLUMN emojicoin_1_balance;
+
+CREATE OR REPLACE FUNCTION save_leaderboard_history() RETURNS trigger AS $$
+    BEGIN
+        INSERT INTO arena_leaderboard_history
+        SELECT
+            "user",
+            NEW.melee_id - 1,
+            profits,
+            losses
+        FROM arena_leaderboard;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER save_leaderboard_history_trigger BEFORE INSERT ON arena_melee_events
+    FOR EACH ROW EXECUTE FUNCTION save_leaderboard_history();
+
+ALTER TABLE arena_positions DROP COLUMN last_exit;
+
+CREATE OR REPLACE FUNCTION update_position_exit() RETURNS trigger AS $$
+    BEGIN
+        UPDATE arena_positions SET
+            open = false,
+            emojicoin_0_balance = 0,
+            emojicoin_1_balance = 0,
+            withdrawals = arena_positions.withdrawals
+                + NEW.emojicoin_0_proceeds
+                    / NEW.emojicoin_0_exchange_rate_base
+                    * NEW.emojicoin_0_exchange_rate_quote
+                + NEW.emojicoin_1_proceeds
+                    / NEW.emojicoin_1_exchange_rate_base
+                    * NEW.emojicoin_1_exchange_rate_quote,
+            deposits = arena_positions.deposits + NEW.tap_out_fee
+        WHERE arena_positions."user" = NEW."user" AND arena_positions.melee_id = NEW.melee_id;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER update_position_exit_trigger AFTER INSERT ON arena_exit_events
+    FOR EACH ROW EXECUTE FUNCTION update_position_exit();

--- a/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/down.sql
@@ -68,7 +68,43 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER save_leaderboard_history_trigger BEFORE INSERT ON arena_melee_events
     FOR EACH ROW EXECUTE FUNCTION save_leaderboard_history();
 
+DROP TRIGGER update_leaderboard_history_trigger ON arena_exit_events;
+DROP FUNCTION update_leaderboard_history;
+
+ALTER TABLE arena_leaderboard_history DROP COLUMN exited;
+
 ALTER TABLE arena_positions DROP COLUMN last_exit;
+ALTER TABLE arena_positions DROP COLUMN match_amount;
+
+CREATE OR REPLACE FUNCTION update_position_enter() RETURNS trigger AS $$
+    BEGIN
+        INSERT INTO arena_positions (
+            "user",
+            melee_id,
+            open,
+            emojicoin_0_balance,
+            emojicoin_1_balance,
+            withdrawals,
+            deposits
+        ) VALUES (
+            NEW."user",
+            NEW.melee_id,
+            true,
+            NEW.emojicoin_0_proceeds,
+            NEW.emojicoin_1_proceeds,
+            0,
+            NEW.input_amount + NEW.match_amount
+        )
+        ON CONFLICT ("user", melee_id) DO
+        UPDATE SET
+            open = true,
+            emojicoin_0_balance = arena_positions.emojicoin_0_balance + NEW.emojicoin_0_proceeds,
+            emojicoin_1_balance = arena_positions.emojicoin_1_balance + NEW.emojicoin_1_proceeds,
+            deposits = arena_positions.deposits + NEW.input_amount + NEW.match_amount
+        WHERE arena_positions."user" = NEW."user" AND arena_positions.melee_id = NEW.melee_id;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION update_position_exit() RETURNS trigger AS $$
     BEGIN
@@ -88,6 +124,9 @@ CREATE OR REPLACE FUNCTION update_position_exit() RETURNS trigger AS $$
         RETURN NEW;
     END;
 $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER update_position_enter_trigger AFTER INSERT ON arena_enter_events
+    FOR EACH ROW EXECUTE FUNCTION update_position_enter();
 
 CREATE OR REPLACE TRIGGER update_position_exit_trigger AFTER INSERT ON arena_exit_events
     FOR EACH ROW EXECUTE FUNCTION update_position_exit();

--- a/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/up.sql
@@ -1,53 +1,11 @@
--- Your SQL goes here
+-- ============================================
+-- Add duplicated metadata fields to arena info
+-- ============================================
+
 ALTER TABLE arena_info ADD COLUMN emojicoin_0_symbols TEXT[];
 ALTER TABLE arena_info ADD COLUMN emojicoin_1_symbols TEXT[];
 ALTER TABLE arena_info ADD COLUMN emojicoin_0_market_id NUMERIC;
 ALTER TABLE arena_info ADD COLUMN emojicoin_1_market_id NUMERIC;
-
-UPDATE arena_info SET
-    emojicoin_0_symbols = (SELECT symbol_emojis FROM market_registration_events AS mre WHERE mre.market_address = arena_info.emojicoin_0_market_address),
-    emojicoin_1_symbols = (SELECT symbol_emojis FROM market_registration_events AS mre WHERE mre.market_address = arena_info.emojicoin_1_market_address),
-    emojicoin_0_market_id = (SELECT market_id FROM market_registration_events AS mre WHERE mre.market_address = arena_info.emojicoin_0_market_address),
-    emojicoin_1_market_id = (SELECT market_id FROM market_registration_events AS mre WHERE mre.market_address = arena_info.emojicoin_1_market_address);
-
-CREATE FUNCTION arena_leaderboard_history_with_arena_info("user" text, "skip" int) RETURNS TABLE (
-    melee_id NUMERIC,
-    profits NUMERIC,
-    losses NUMERIC,
-
-    emojicoin_0_symbols TEXT[],
-    emojicoin_1_symbols TEXT[],
-    emojicoin_0_market_address TEXT,
-    emojicoin_1_market_address TEXT,
-    emojicoin_0_market_id NUMERIC,
-    emojicoin_1_market_id NUMERIC,
-    start_time TIMESTAMP,
-    duration NUMERIC
-)
-AS $$
-SELECT
-    arena_leaderboard_history.melee_id,
-    arena_leaderboard_history.profits,
-    arena_leaderboard_history.losses,
-
-    arena_info.emojicoin_0_symbols,
-    arena_info.emojicoin_1_symbols,
-    arena_info.emojicoin_0_market_address,
-    arena_info.emojicoin_1_market_address,
-    arena_info.emojicoin_0_market_id,
-    arena_info.emojicoin_1_market_id,
-    arena_info.start_time,
-    arena_info.duration
-FROM
-    arena_leaderboard_history
-INNER JOIN
-    arena_info
-ON
-    arena_info.melee_id = arena_leaderboard_history.melee_id
-WHERE "user" = $1
-LIMIT 20
-OFFSET $2
-$$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION create_melee_info() RETURNS trigger AS $$
     BEGIN
@@ -107,3 +65,123 @@ $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE TRIGGER create_melee_info_trigger AFTER INSERT ON arena_melee_events
     FOR EACH ROW EXECUTE FUNCTION create_melee_info();
+
+-- =================================================================
+-- Add last exit and end holdings information to leaderboard history
+-- =================================================================
+
+ALTER TABLE arena_leaderboard_history ADD COLUMN last_exit TEXT;
+ALTER TABLE arena_leaderboard_history ADD COLUMN emojicoin_0_balance NUMERIC NOT NULL;
+ALTER TABLE arena_leaderboard_history ADD COLUMN emojicoin_1_balance NUMERIC NOT NULL;
+
+CREATE OR REPLACE FUNCTION save_leaderboard_history() RETURNS trigger AS $$
+    BEGIN
+        INSERT INTO arena_leaderboard_history
+        SELECT
+            "user",
+            NEW.melee_id - 1,
+            profits,
+            losses,
+            (
+                WITH last_exit AS (
+                    SELECT * FROM arena_exit_events AS aee
+                    WHERE aee.melee_id = arena_leaderboard_history.melee_id
+                    AND aee."user" = arena_leaderboard_history."user"
+                    ORDER BY transaction_version DESC, event_index DESC
+                    LIMIT 1
+                ),
+                melee AS (
+                    SELECT * FROM arena_melee_events AS ame
+                    WHERE ame.melee_id = arena_leaderboard_history.melee_id
+                )
+                SELECT
+                    CASE
+                        WHEN (SELECT emojicoin_0_proceeds FROM last_exit) = 0 THEN (SELECT emojicoin_1_market_address FROM melee)
+                        WHEN (SELECT emojicoin_1_proceeds FROM last_exit) = 0 THEN (SELECT emojicoin_0_market_address FROM melee)
+                        ELSE NULL -- aka never exited
+                    END
+            ),
+            emojicoin_0_balance,
+            emojicoin_1_balance
+        FROM arena_leaderboard;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER save_leaderboard_history_trigger BEFORE INSERT ON arena_melee_events
+    FOR EACH ROW EXECUTE FUNCTION save_leaderboard_history();
+
+-- ======================================
+-- Add last exit information to positions
+-- ======================================
+
+ALTER TABLE arena_positions ADD COLUMN last_exit TEXT NOT NULL;
+
+CREATE OR REPLACE FUNCTION update_position_exit() RETURNS trigger AS $$
+    BEGIN
+        UPDATE arena_positions SET
+            open = false,
+            emojicoin_0_balance = 0,
+            emojicoin_1_balance = 0,
+            withdrawals = arena_positions.withdrawals
+                + NEW.emojicoin_0_proceeds
+                    / NEW.emojicoin_0_exchange_rate_base
+                    * NEW.emojicoin_0_exchange_rate_quote
+                + NEW.emojicoin_1_proceeds
+                    / NEW.emojicoin_1_exchange_rate_base
+                    * NEW.emojicoin_1_exchange_rate_quote,
+            deposits = arena_positions.deposits + NEW.tap_out_fee,
+            last_exit = CASE
+                WHEN NEW.emojicoin_1_proceeds = 0 THEN (SELECT emojicoin_0_market_address FROM arena_melee_events AS ame WHERE ame.melee_id = NEW.melee_id)
+                ELSE (SELECT emojicoin_1_market_address FROM arena_melee_events AS ame WHERE ame.melee_id = NEW.melee_id)
+            END
+        WHERE arena_positions."user" = NEW."user" AND arena_positions.melee_id = NEW.melee_id;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER update_position_exit_trigger AFTER INSERT ON arena_exit_events
+    FOR EACH ROW EXECUTE FUNCTION update_position_exit();
+
+-- =================================================================
+-- Add new endpoint to get personal history with embedded melee info
+-- =================================================================
+
+CREATE FUNCTION arena_leaderboard_history_with_arena_info("user" text, "skip" int) RETURNS TABLE (
+    melee_id NUMERIC,
+    profits NUMERIC,
+    losses NUMERIC,
+
+    emojicoin_0_symbols TEXT[],
+    emojicoin_1_symbols TEXT[],
+    emojicoin_0_market_address TEXT,
+    emojicoin_1_market_address TEXT,
+    emojicoin_0_market_id NUMERIC,
+    emojicoin_1_market_id NUMERIC,
+    start_time TIMESTAMP,
+    duration NUMERIC
+)
+AS $$
+SELECT
+    arena_leaderboard_history.melee_id,
+    arena_leaderboard_history.profits,
+    arena_leaderboard_history.losses,
+
+    arena_info.emojicoin_0_symbols,
+    arena_info.emojicoin_1_symbols,
+    arena_info.emojicoin_0_market_address,
+    arena_info.emojicoin_1_market_address,
+    arena_info.emojicoin_0_market_id,
+    arena_info.emojicoin_1_market_id,
+    arena_info.start_time,
+    arena_info.duration
+FROM
+    arena_leaderboard_history
+INNER JOIN
+    arena_info
+ON
+    arena_info.melee_id = arena_leaderboard_history.melee_id
+WHERE "user" = $1
+LIMIT 20
+OFFSET $2
+$$ LANGUAGE SQL;

--- a/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/up.sql
@@ -1,0 +1,55 @@
+-- Your SQL goes here
+ALTER TABLE arena_info ADD COLUMN emojicoin_0_symbols TEXT[];
+ALTER TABLE arena_info ADD COLUMN emojicoin_1_symbols TEXT[];
+ALTER TABLE arena_info ADD COLUMN emojicoin_0_market_id NUMERIC;
+ALTER TABLE arena_info ADD COLUMN emojicoin_1_market_id NUMERIC;
+
+UPDATE arena_info SET
+    emojicoin_0_symbols = (SELECT symbol_emojis FROM market_registration_events AS mre WHERE mre.market_address = arena_info.emojicoin_0_market_address),
+    emojicoin_1_symbols = (SELECT symbol_emojis FROM market_registration_events AS mre WHERE mre.market_address = arena_info.emojicoin_1_market_address),
+    emojicoin_0_market_id = (SELECT market_id FROM market_registration_events AS mre WHERE mre.market_address = arena_info.emojicoin_0_market_address),
+    emojicoin_1_market_id = (SELECT market_id FROM market_registration_events AS mre WHERE mre.market_address = arena_info.emojicoin_1_market_address);
+
+ALTER TABLE arena_info ALTER COLUMN emojicoin_0_symbols SET NOT NULL;
+ALTER TABLE arena_info ALTER COLUMN emojicoin_1_symbols SET NOT NULL;
+ALTER TABLE arena_info ALTER COLUMN emojicoin_0_market_id SET NOT NULL;
+ALTER TABLE arena_info ALTER COLUMN emojicoin_1_market_id SET NOT NULL;
+
+CREATE FUNCTION arena_leaderboard_history_with_arena_info("user" text, "skip" int) RETURNS TABLE (
+    melee_id NUMERIC,
+    profits NUMERIC,
+    losses NUMERIC,
+
+    emojicoin_0_symbols TEXT[],
+    emojicoin_1_symbols TEXT[],
+    emojicoin_0_market_address TEXT,
+    emojicoin_1_market_address TEXT,
+    emojicoin_0_market_id NUMERIC,
+    emojicoin_1_market_id NUMERIC,
+    start_time TIMESTAMP,
+    duration NUMERIC
+)
+AS $$
+SELECT
+    arena_leaderboard_history.melee_id,
+    arena_leaderboard_history.profits,
+    arena_leaderboard_history.losses,
+
+    arena_info.emojicoin_0_symbols,
+    arena_info.emojicoin_1_symbols,
+    arena_info.emojicoin_0_market_address,
+    arena_info.emojicoin_1_market_address,
+    arena_info.emojicoin_0_market_id,
+    arena_info.emojicoin_1_market_id,
+    arena_info.start_time,
+    arena_info.duration
+FROM
+    arena_leaderboard_history
+INNER JOIN
+    arena_info
+ON
+    arena_info.melee_id = arena_leaderboard_history.melee_id
+WHERE "user" = $1
+LIMIT 20
+OFFSET $2
+$$ LANGUAGE SQL;

--- a/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/up.sql
@@ -73,6 +73,7 @@ CREATE OR REPLACE TRIGGER create_melee_info_trigger AFTER INSERT ON arena_melee_
 ALTER TABLE arena_leaderboard_history ADD COLUMN last_exit TEXT;
 ALTER TABLE arena_leaderboard_history ADD COLUMN emojicoin_0_balance NUMERIC NOT NULL;
 ALTER TABLE arena_leaderboard_history ADD COLUMN emojicoin_1_balance NUMERIC NOT NULL;
+ALTER TABLE arena_leaderboard_history ADD COLUMN exited BOOLEAN NOT NULL;
 
 CREATE OR REPLACE FUNCTION save_leaderboard_history() RETURNS trigger AS $$
     BEGIN
@@ -80,42 +81,88 @@ CREATE OR REPLACE FUNCTION save_leaderboard_history() RETURNS trigger AS $$
         SELECT
             "user",
             NEW.melee_id - 1,
-            profits,
-            losses,
+            arena_leaderboard.profits,
+            arena_leaderboard.losses,
             (
                 WITH last_exit AS (
                     SELECT * FROM arena_exit_events AS aee
-                    WHERE aee.melee_id = arena_leaderboard_history.melee_id
-                    AND aee."user" = arena_leaderboard_history."user"
+                    WHERE aee.melee_id = NEW.melee_id - 1
+                    AND aee."user" = arena_leaderboard."user"
                     ORDER BY transaction_version DESC, event_index DESC
                     LIMIT 1
                 ),
                 melee AS (
                     SELECT * FROM arena_melee_events AS ame
-                    WHERE ame.melee_id = arena_leaderboard_history.melee_id
+                    WHERE ame.melee_id = NEW.melee_id - 1
                 )
                 SELECT
                     CASE
-                        WHEN (SELECT emojicoin_0_proceeds FROM last_exit) = 0 THEN (SELECT emojicoin_1_market_address FROM melee)
-                        WHEN (SELECT emojicoin_1_proceeds FROM last_exit) = 0 THEN (SELECT emojicoin_0_market_address FROM melee)
+                        WHEN (SELECT last_exit.emojicoin_0_proceeds FROM last_exit) = 0 THEN (SELECT melee.emojicoin_1_market_address FROM melee)
+                        WHEN (SELECT last_exit.emojicoin_1_proceeds FROM last_exit) = 0 THEN (SELECT melee.emojicoin_0_market_address FROM melee)
                         ELSE NULL -- aka never exited
                     END
             ),
-            emojicoin_0_balance,
-            emojicoin_1_balance
+            arena_leaderboard.emojicoin_0_balance,
+            arena_leaderboard.emojicoin_1_balance,
+            CASE WHEN arena_leaderboard.emojicoin_0_balance + arena_leaderboard.emojicoin_1_balance = 0 THEN true ELSE false END
         FROM arena_leaderboard;
         RETURN NEW;
     END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER save_leaderboard_history_trigger BEFORE INSERT ON arena_melee_events
-    FOR EACH ROW EXECUTE FUNCTION save_leaderboard_history();
+CREATE OR REPLACE FUNCTION update_leaderboard_history() RETURNS trigger AS $$
+    BEGIN
+        UPDATE arena_leaderboard_history
+        SET exited = true
+        WHERE arena_leaderboard_history.melee_id = NEW.melee_id
+        AND arena_leaderboard_history."user" = NEW."user";
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER update_leaderboard_history_trigger BEFORE INSERT ON arena_exit_events
+    FOR EACH ROW EXECUTE FUNCTION update_leaderboard_history();
 
 -- ======================================
 -- Add last exit information to positions
 -- ======================================
 
-ALTER TABLE arena_positions ADD COLUMN last_exit TEXT NOT NULL;
+ALTER TABLE arena_positions ADD COLUMN last_exit TEXT;
+ALTER TABLE arena_positions ADD COLUMN match_amount NUMERIC NOT NULL;
+
+CREATE OR REPLACE FUNCTION update_position_enter() RETURNS trigger AS $$
+    BEGIN
+        INSERT INTO arena_positions (
+            "user",
+            melee_id,
+            open,
+            emojicoin_0_balance,
+            emojicoin_1_balance,
+            withdrawals,
+            deposits,
+            match_amount
+        ) VALUES (
+            NEW."user",
+            NEW.melee_id,
+            true,
+            NEW.emojicoin_0_proceeds,
+            NEW.emojicoin_1_proceeds,
+            0,
+            NEW.input_amount + NEW.match_amount,
+            CASE WHEN NEW.match_amount > 0 THEN true ELSE false END,
+            NEW.match_amount
+        )
+        ON CONFLICT ("user", melee_id) DO
+        UPDATE SET
+            open = true,
+            emojicoin_0_balance = arena_positions.emojicoin_0_balance + NEW.emojicoin_0_proceeds,
+            emojicoin_1_balance = arena_positions.emojicoin_1_balance + NEW.emojicoin_1_proceeds,
+            deposits = arena_positions.deposits + NEW.input_amount + NEW.match_amount,
+            match_amount = arena_positions.match_amount + NEW.match_amount
+        WHERE arena_positions."user" = NEW."user" AND arena_positions.melee_id = NEW.melee_id;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION update_position_exit() RETURNS trigger AS $$
     BEGIN
@@ -134,11 +181,15 @@ CREATE OR REPLACE FUNCTION update_position_exit() RETURNS trigger AS $$
             last_exit = CASE
                 WHEN NEW.emojicoin_1_proceeds = 0 THEN (SELECT emojicoin_0_market_address FROM arena_melee_events AS ame WHERE ame.melee_id = NEW.melee_id)
                 ELSE (SELECT emojicoin_1_market_address FROM arena_melee_events AS ame WHERE ame.melee_id = NEW.melee_id)
-            END
+            END,
+            match_amount = arena_positions.match_amount - NEW.tap_out_fee
         WHERE arena_positions."user" = NEW."user" AND arena_positions.melee_id = NEW.melee_id;
         RETURN NEW;
     END;
 $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER update_position_enter_trigger AFTER INSERT ON arena_enter_events
+    FOR EACH ROW EXECUTE FUNCTION update_position_enter();
 
 CREATE OR REPLACE TRIGGER update_position_exit_trigger AFTER INSERT ON arena_exit_events
     FOR EACH ROW EXECUTE FUNCTION update_position_exit();

--- a/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/up.sql
@@ -149,7 +149,6 @@ CREATE OR REPLACE FUNCTION update_position_enter() RETURNS trigger AS $$
             NEW.emojicoin_1_proceeds,
             0,
             NEW.input_amount + NEW.match_amount,
-            CASE WHEN NEW.match_amount > 0 THEN true ELSE false END,
             NEW.match_amount
         )
         ON CONFLICT ("user", melee_id) DO

--- a/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-31-170951_emojicoin_arena_add_emojis/up.sql
@@ -10,11 +10,6 @@ UPDATE arena_info SET
     emojicoin_0_market_id = (SELECT market_id FROM market_registration_events AS mre WHERE mre.market_address = arena_info.emojicoin_0_market_address),
     emojicoin_1_market_id = (SELECT market_id FROM market_registration_events AS mre WHERE mre.market_address = arena_info.emojicoin_1_market_address);
 
-ALTER TABLE arena_info ALTER COLUMN emojicoin_0_symbols SET NOT NULL;
-ALTER TABLE arena_info ALTER COLUMN emojicoin_1_symbols SET NOT NULL;
-ALTER TABLE arena_info ALTER COLUMN emojicoin_0_market_id SET NOT NULL;
-ALTER TABLE arena_info ALTER COLUMN emojicoin_1_market_id SET NOT NULL;
-
 CREATE FUNCTION arena_leaderboard_history_with_arena_info("user" text, "skip" int) RETURNS TABLE (
     melee_id NUMERIC,
     profits NUMERIC,
@@ -53,3 +48,62 @@ WHERE "user" = $1
 LIMIT 20
 OFFSET $2
 $$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION create_melee_info() RETURNS trigger AS $$
+    BEGIN
+        WITH market0 AS (
+            SELECT * FROM market_registration_events WHERE market_address = NEW.emojicoin_0_market_address
+        ), market1 AS (
+            SELECT * FROM market_registration_events WHERE market_address = NEW.emojicoin_1_market_address
+        )
+        INSERT INTO arena_info (
+            melee_id,
+            volume,
+            rewards_remaining,
+            apt_locked,
+            emojicoin_0_market_address,
+            emojicoin_1_market_address,
+            start_time,
+            duration,
+            max_match_percentage,
+            max_match_amount,
+            emojicoin_0_symbols,
+            emojicoin_1_symbols,
+            emojicoin_0_market_id,
+            emojicoin_1_market_id
+        ) VALUES (
+            NEW.melee_id,
+            0,
+            NEW.available_rewards,
+            0,
+            NEW.emojicoin_0_market_address,
+            NEW.emojicoin_1_market_address,
+            NEW.start_time,
+            NEW.duration,
+            NEW.max_match_percentage,
+            NEW.max_match_amount,
+            (SELECT symbol_emojis FROM market0),
+            (SELECT symbol_emojis FROM market1),
+            (SELECT market_id FROM market0),
+            (SELECT market_id FROM market1)
+        )
+        ON CONFLICT (melee_id) DO
+        UPDATE SET
+            rewards_remaining = arena_info.rewards_remaining + NEW.available_rewards,
+            emojicoin_0_market_address = NEW.emojicoin_0_market_address,
+            emojicoin_1_market_address = NEW.emojicoin_1_market_address,
+            start_time = NEW.start_time,
+            duration = NEW.duration,
+            max_match_percentage = NEW.max_match_percentage,
+            max_match_amount = NEW.max_match_amount,
+            emojicoin_0_symbols = (SELECT symbol_emojis FROM market0),
+            emojicoin_1_symbols = (SELECT symbol_emojis FROM market1),
+            emojicoin_0_market_id = (SELECT market_id FROM market0),
+            emojicoin_1_market_id = (SELECT market_id FROM market1)
+        WHERE arena_info.melee_id = NEW.melee_id;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER create_melee_info_trigger AFTER INSERT ON arena_melee_events
+    FOR EACH ROW EXECUTE FUNCTION create_melee_info();

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -153,6 +153,10 @@ diesel::table! {
         duration -> Nullable<Numeric>,
         max_match_percentage -> Nullable<Numeric>,
         max_match_amount -> Nullable<Numeric>,
+        emojicoin_0_symbols -> Array<Nullable<Text>>,
+        emojicoin_1_symbols -> Array<Nullable<Text>>,
+        emojicoin_0_market_id -> Numeric,
+        emojicoin_1_market_id -> Numeric,
     }
 }
 

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -153,10 +153,10 @@ diesel::table! {
         duration -> Nullable<Numeric>,
         max_match_percentage -> Nullable<Numeric>,
         max_match_amount -> Nullable<Numeric>,
-        emojicoin_0_symbols -> Array<Nullable<Text>>,
-        emojicoin_1_symbols -> Array<Nullable<Text>>,
-        emojicoin_0_market_id -> Numeric,
-        emojicoin_1_market_id -> Numeric,
+        emojicoin_0_symbols -> Nullable<Array<Nullable<Text>>>,
+        emojicoin_1_symbols -> Nullable<Array<Nullable<Text>>>,
+        emojicoin_0_market_id -> Nullable<Numeric>,
+        emojicoin_1_market_id -> Nullable<Numeric>,
     }
 }
 
@@ -166,6 +166,9 @@ diesel::table! {
         melee_id -> Numeric,
         profits -> Numeric,
         losses -> Numeric,
+        last_exit -> Nullable<Text>,
+        emojicoin_0_balance -> Numeric,
+        emojicoin_1_balance -> Numeric,
     }
 }
 
@@ -199,6 +202,7 @@ diesel::table! {
         emojicoin_1_balance -> Numeric,
         withdrawals -> Numeric,
         deposits -> Numeric,
+        last_exit -> Text,
     }
 }
 

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -169,6 +169,7 @@ diesel::table! {
         last_exit -> Nullable<Text>,
         emojicoin_0_balance -> Numeric,
         emojicoin_1_balance -> Numeric,
+        exited -> Bool,
     }
 }
 
@@ -202,7 +203,8 @@ diesel::table! {
         emojicoin_1_balance -> Numeric,
         withdrawals -> Numeric,
         deposits -> Numeric,
-        last_exit -> Text,
+        last_exit -> Nullable<Text>,
+        match_amount -> Numeric,
     }
 }
 


### PR DESCRIPTION
This PR adds a couple of redundant columns to `arena_info` in order to avoid querying multiple times the backend when loading the home page and the arena page. It also creates a function to get the arena history with those columns.