### PR TITLE
[ECO-2734] Bump builder version

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_VERSION=1.0.0
+ARG BUILDER_VERSION=1.1.0
 
 # Configure base image with buildtime dependencies.
 FROM econialabs/rust-builder:$BUILDER_VERSION AS base


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

1. Bump `rust-builder` base image for new compiler version

# Testing

1. Compiles locally on ARM64
