### PR TITLE
feat(ECO-2865): Update models to work with new schema

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/enums.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/enums.rs
@@ -5,16 +5,7 @@ use super::{
         MARKET_REGISTRATION_EVENT, MARKET_RESOURCE, PERIODIC_STATE_EVENT, STATE_EVENT, SWAP_EVENT,
     },
     json_types::{ArenaEvent, EventWithMarket, GlobalStateEvent},
-    models::{
-        arena_enter_event::ArenaEnterEventModel, arena_exit_event::ArenaExitEventModel,
-        arena_melee_event::ArenaMeleeEventModel, arena_swap_event::ArenaSwapEventModel,
-        arena_vault_balance_update_event::ArenaVaultBalanceUpdateEventModel,
-        chat_event::ChatEventModel, global_state_event::GlobalStateEventModel,
-        liquidity_event::LiquidityEventModel,
-        market_latest_state_event::MarketLatestStateEventModel,
-        market_registration_event::MarketRegistrationEventModel,
-        periodic_state_event::PeriodicStateEventModel, swap_event::SwapEventModel,
-    },
+    models::prelude::*,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_exit_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_exit_event.rs
@@ -23,6 +23,7 @@ pub struct ArenaExitEventModel {
 
     pub emojicoin_0_proceeds: BigDecimal,
     pub emojicoin_1_proceeds: BigDecimal,
+    pub apt_proceeds: BigDecimal,
     pub emojicoin_0_exchange_rate_base: BigDecimal,
     pub emojicoin_0_exchange_rate_quote: BigDecimal,
     pub emojicoin_1_exchange_rate_base: BigDecimal,
@@ -43,8 +44,15 @@ impl ArenaExitEventModel {
             melee_id: arena_exit_event.melee_id,
             tap_out_fee: arena_exit_event.tap_out_fee,
 
-            emojicoin_0_proceeds: arena_exit_event.emojicoin_0_proceeds,
-            emojicoin_1_proceeds: arena_exit_event.emojicoin_1_proceeds,
+            emojicoin_0_proceeds: arena_exit_event.emojicoin_0_proceeds.clone(),
+            emojicoin_1_proceeds: arena_exit_event.emojicoin_1_proceeds.clone(),
+            apt_proceeds: (arena_exit_event.emojicoin_0_proceeds
+                / arena_exit_event.emojicoin_0_exchange_rate.base.clone()
+                * arena_exit_event.emojicoin_0_exchange_rate.quote.clone()
+                + arena_exit_event.emojicoin_1_proceeds
+                    / arena_exit_event.emojicoin_1_exchange_rate.base.clone()
+                    * arena_exit_event.emojicoin_1_exchange_rate.quote.clone())
+            .round(0),
             emojicoin_0_exchange_rate_base: arena_exit_event.emojicoin_0_exchange_rate.base,
             emojicoin_0_exchange_rate_quote: arena_exit_event.emojicoin_0_exchange_rate.quote,
             emojicoin_1_exchange_rate_base: arena_exit_event.emojicoin_1_exchange_rate.base,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_info.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_info.rs
@@ -1,0 +1,123 @@
+use super::{
+    arena_enter_event::ArenaEnterEventModel, arena_exit_event::ArenaExitEventModel,
+    arena_melee_event::ArenaMeleeEventModel, arena_swap_event::ArenaSwapEventModel,
+};
+use crate::{db::common::models::emojicoin_models::json_types::SwapEvent, schema::arena_info};
+use bigdecimal::BigDecimal;
+use field_count::FieldCount;
+use num::Zero;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(melee_id))]
+#[diesel(table_name = arena_info)]
+pub struct ArenaInfoModel {
+    pub melee_id: BigDecimal,
+    pub volume: BigDecimal,
+    pub rewards_remaining: BigDecimal,
+    pub emojicoin_0_locked: BigDecimal,
+    pub emojicoin_1_locked: BigDecimal,
+
+    pub emojicoin_0_market_address: String,
+    pub emojicoin_1_market_address: String,
+    pub emojicoin_0_market_id: BigDecimal,
+    pub emojicoin_1_market_id: BigDecimal,
+    pub emojicoin_0_symbols: Vec<String>,
+    pub emojicoin_1_symbols: Vec<String>,
+    pub start_time: chrono::NaiveDateTime,
+    pub duration: BigDecimal,
+    pub max_match_percentage: BigDecimal,
+    pub max_match_amount: BigDecimal,
+}
+
+pub struct ArenaInfoData {
+    pub emojicoin_0_market_id: BigDecimal,
+    pub emojicoin_1_market_id: BigDecimal,
+    pub emojicoin_0_symbols: Vec<String>,
+    pub emojicoin_1_symbols: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ArenaInfoDiffUpdate {
+    pub melee_id: BigDecimal,
+    pub volume: BigDecimal,
+    pub rewards_remaining: BigDecimal,
+    pub emojicoin_0_locked: BigDecimal,
+    pub emojicoin_1_locked: BigDecimal,
+}
+
+impl ArenaInfoModel {
+    pub fn new(arena_melee_event: ArenaMeleeEventModel, data: ArenaInfoData) -> ArenaInfoModel {
+        ArenaInfoModel {
+            melee_id: arena_melee_event.melee_id,
+            volume: BigDecimal::zero(),
+            rewards_remaining: arena_melee_event.available_rewards,
+            emojicoin_0_locked: BigDecimal::zero(),
+            emojicoin_1_locked: BigDecimal::zero(),
+
+            emojicoin_0_market_address: arena_melee_event.emojicoin_0_market_address,
+            emojicoin_1_market_address: arena_melee_event.emojicoin_1_market_address,
+            emojicoin_0_market_id: data.emojicoin_0_market_id,
+            emojicoin_1_market_id: data.emojicoin_1_market_id,
+            emojicoin_0_symbols: data.emojicoin_0_symbols,
+            emojicoin_1_symbols: data.emojicoin_1_symbols,
+            start_time: arena_melee_event.start_time,
+            duration: arena_melee_event.duration,
+            max_match_percentage: arena_melee_event.max_match_percentage,
+            max_match_amount: arena_melee_event.max_match_amount,
+        }
+    }
+}
+
+impl From<ArenaEnterEventModel> for ArenaInfoDiffUpdate {
+    fn from(value: ArenaEnterEventModel) -> Self {
+        Self {
+            melee_id: value.melee_id,
+            volume: value.quote_volume.clone(),
+            rewards_remaining: -value.match_amount,
+            emojicoin_0_locked: value.emojicoin_0_proceeds,
+            emojicoin_1_locked: value.emojicoin_1_proceeds,
+        }
+    }
+}
+
+impl ArenaInfoDiffUpdate {
+    pub fn from_swaps(value: ArenaSwapEventModel, swaps: (SwapEvent, SwapEvent)) -> Self {
+        Self {
+            melee_id: value.melee_id,
+            volume: value.quote_volume,
+            rewards_remaining: BigDecimal::zero(),
+            emojicoin_0_locked: swaps.0.base_volume * if swaps.0.is_sell { -1 } else { 1 },
+            emojicoin_1_locked: swaps.1.base_volume * if swaps.1.is_sell { -1 } else { 1 },
+        }
+    }
+}
+impl From<ArenaExitEventModel> for ArenaInfoDiffUpdate {
+    fn from(value: ArenaExitEventModel) -> Self {
+        Self {
+            melee_id: value.melee_id,
+            volume: BigDecimal::zero(),
+            rewards_remaining: -value.tap_out_fee,
+            emojicoin_0_locked: -value.emojicoin_0_proceeds,
+            emojicoin_1_locked: -value.emojicoin_1_proceeds,
+        }
+    }
+}
+
+impl ArenaInfoDiffUpdate {
+    pub fn merge(values: Vec<Self>) -> Vec<Self> {
+        let mut map: HashMap<BigDecimal, ArenaInfoDiffUpdate> = HashMap::new();
+        for value in values {
+            map.entry(value.melee_id.clone())
+                .and_modify(|a| {
+                    a.volume += value.volume.clone();
+                    a.rewards_remaining += value.rewards_remaining.clone();
+                    a.emojicoin_0_locked += value.emojicoin_0_locked.clone();
+                    a.emojicoin_1_locked += value.emojicoin_1_locked.clone();
+                })
+                .or_insert(value);
+        }
+        map.into_values().collect()
+    }
+}

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_position.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_position.rs
@@ -1,0 +1,131 @@
+use crate::{
+    db::common::models::emojicoin_models::json_types::{
+        ArenaEnterEvent, ArenaExitEvent, ArenaSwapEvent, SwapEvent,
+    },
+    schema::arena_position,
+};
+use bigdecimal::BigDecimal;
+use field_count::FieldCount;
+use num::Zero;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(melee_id))]
+#[diesel(table_name = arena_position)]
+/// Arena position difference model.
+///
+/// The fields represent not the amount after an event, but the difference in that amount generated
+/// by the event.
+///
+/// For example, an enter would produce the following model:
+///
+/// ```json5
+/// {
+///     // ...
+///     "emojicoin_0_balance": 123,
+///     "emojicoin_1_balance": 0,
+///     // ...
+/// }
+/// ```
+///
+/// And a subsequent swap would produce:
+///
+/// ```json5
+/// {
+///     // ...
+///     "emojicoin_0_balance": -123,
+///     "emojicoin_1_balance": 987,
+///     // ...
+/// }
+/// ```
+///
+/// This means that we can insert events into the database out of order without risking to insert
+/// outdated data.
+pub struct ArenaPositionDiffModel {
+    pub user: String,
+    pub melee_id: BigDecimal,
+    pub open: bool,
+    pub emojicoin_0_balance: BigDecimal,
+    pub emojicoin_1_balance: BigDecimal,
+    pub withdrawals: BigDecimal,
+    pub deposits: BigDecimal,
+    pub match_amount: BigDecimal,
+    pub last_exit_0: Option<bool>,
+}
+
+impl From<ArenaEnterEvent> for ArenaPositionDiffModel {
+    fn from(arena_enter_event: ArenaEnterEvent) -> ArenaPositionDiffModel {
+        ArenaPositionDiffModel {
+            user: arena_enter_event.user,
+            melee_id: arena_enter_event.melee_id,
+            open: true,
+            emojicoin_0_balance: arena_enter_event.emojicoin_0_proceeds,
+            emojicoin_1_balance: arena_enter_event.emojicoin_1_proceeds,
+            withdrawals: BigDecimal::zero(),
+            deposits: arena_enter_event.input_amount,
+            match_amount: arena_enter_event.match_amount,
+            last_exit_0: None,
+        }
+    }
+}
+
+impl ArenaPositionDiffModel {
+    pub fn from_swap(
+        arena_swap_event: ArenaSwapEvent,
+        swaps: (SwapEvent, SwapEvent),
+    ) -> ArenaPositionDiffModel {
+        ArenaPositionDiffModel {
+            user: arena_swap_event.user,
+            melee_id: arena_swap_event.melee_id,
+            open: true,
+            emojicoin_0_balance: swaps.0.base_volume * if swaps.0.is_sell { -1 } else { 1 },
+            emojicoin_1_balance: swaps.1.base_volume * if swaps.1.is_sell { -1 } else { 1 },
+            withdrawals: BigDecimal::zero(),
+            deposits: BigDecimal::zero(),
+            match_amount: BigDecimal::zero(),
+            last_exit_0: None,
+        }
+    }
+
+    pub fn merge(arena_positions: Vec<Self>) -> Vec<Self> {
+        let mut map: HashMap<(BigDecimal, String), Self> = HashMap::new();
+        for position in arena_positions {
+            let position_clone = position.clone();
+            map.entry((position.melee_id, position.user))
+                .and_modify(|p| {
+                    p.open = position.open;
+                    p.emojicoin_0_balance += position.emojicoin_0_balance;
+                    p.emojicoin_1_balance += position.emojicoin_1_balance;
+                    p.withdrawals += position.withdrawals;
+                    p.deposits += position.deposits;
+                    p.match_amount += position.match_amount;
+                    p.last_exit_0 = position.last_exit_0;
+                })
+                .or_insert(position_clone);
+        }
+        map.into_values().collect()
+    }
+}
+
+impl From<ArenaExitEvent> for ArenaPositionDiffModel {
+    fn from(arena_exit_event: ArenaExitEvent) -> ArenaPositionDiffModel {
+        ArenaPositionDiffModel {
+            user: arena_exit_event.user,
+            melee_id: arena_exit_event.melee_id,
+            open: false,
+            emojicoin_0_balance: -arena_exit_event.emojicoin_0_proceeds.clone(),
+            emojicoin_1_balance: -arena_exit_event.emojicoin_1_proceeds.clone(),
+            withdrawals: (arena_exit_event.emojicoin_0_proceeds
+                / arena_exit_event.emojicoin_0_exchange_rate.base
+                * arena_exit_event.emojicoin_0_exchange_rate.quote
+                + arena_exit_event.emojicoin_1_proceeds.clone()
+                    / arena_exit_event.emojicoin_1_exchange_rate.base
+                    * arena_exit_event.emojicoin_1_exchange_rate.quote)
+                .round(0),
+            deposits: BigDecimal::zero(),
+            match_amount: -arena_exit_event.tap_out_fee,
+            last_exit_0: Some(arena_exit_event.emojicoin_1_proceeds.is_zero()),
+        }
+    }
+}

--- a/rust/processor/src/db/common/models/emojicoin_models/models/market_1m_periods_in_last_day.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/market_1m_periods_in_last_day.rs
@@ -8,7 +8,6 @@ use chrono::NaiveDateTime;
 use diesel::{
     dsl::{now, IntervalDsl},
     result::Error,
-    QueryResult,
 };
 use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection};
 use field_count::FieldCount;
@@ -43,7 +42,7 @@ impl MarketOneMinutePeriodsInLastDayModel {
     pub async fn insert_and_delete_periods(
         items: &[MarketOneMinutePeriodsInLastDayModel],
         pool: ArcDbPool,
-    ) -> QueryResult<(usize, usize)> {
+    ) -> Result<(), diesel::result::Error> {
         use diesel::prelude::*;
         use schema::market_1m_periods_in_last_day::dsl::*;
 
@@ -77,6 +76,8 @@ impl MarketOneMinutePeriodsInLastDayModel {
             }
             .scope_boxed()
         })
-        .await
+        .await?;
+
+        Ok(())
     }
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/models/mod.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/mod.rs
@@ -1,6 +1,8 @@
 pub mod arena_enter_event;
 pub mod arena_exit_event;
+pub mod arena_info;
 pub mod arena_melee_event;
+pub mod arena_position;
 pub mod arena_swap_event;
 pub mod arena_vault_balance_update_event;
 pub mod chat_event;
@@ -13,3 +15,13 @@ pub mod market_registration_event;
 pub mod periodic_state_event;
 pub mod swap_event;
 pub mod user_liquidity_pools;
+
+pub mod prelude {
+    pub use super::{
+        arena_enter_event::*, arena_exit_event::*, arena_info::*, arena_melee_event::*,
+        arena_position::*, arena_swap_event::*, arena_vault_balance_update_event::*, chat_event::*,
+        global_state_event::*, liquidity_event::*, market_1m_periods_in_last_day::*,
+        market_24h_rolling_volume::*, market_latest_state_event::*, market_registration_event::*,
+        periodic_state_event::*, swap_event::*, user_liquidity_pools::*,
+    };
+}

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
@@ -1,15 +1,5 @@
 use crate::{
-    db::common::models::emojicoin_models::models::{
-        arena_enter_event::ArenaEnterEventModel, arena_exit_event::ArenaExitEventModel,
-        arena_melee_event::ArenaMeleeEventModel, arena_swap_event::ArenaSwapEventModel,
-        arena_vault_balance_update_event::ArenaVaultBalanceUpdateEventModel,
-        chat_event::ChatEventModel, global_state_event::GlobalStateEventModel,
-        liquidity_event::LiquidityEventModel,
-        market_latest_state_event::MarketLatestStateEventModel,
-        market_registration_event::MarketRegistrationEventModel,
-        periodic_state_event::PeriodicStateEventModel, swap_event::SwapEventModel,
-        user_liquidity_pools::UserLiquidityPoolsModel,
-    },
+    db::common::models::emojicoin_models::models::prelude::*,
     schema,
 };
 use diesel::{


### PR DESCRIPTION
This PR updates the arena specific models according to the new DB field and table changes. It also adds the models for tables which previously didn't have models in rust.