### PR TITLE
chore(ECO-2940): Add `last_transaction_version` for tables that track the latest state of something

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/constants.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/constants.rs
@@ -1,4 +1,5 @@
 use lazy_static::lazy_static;
+use std::num::NonZeroU64;
 
 // Only for use below to construct the lazy static strings.
 const SWAP: &str = "::emojicoin_dot_fun::Swap";
@@ -14,6 +15,7 @@ const ARENA_ENTER: &str = "::emojicoin_arena::Enter";
 const ARENA_EXIT: &str = "::emojicoin_arena::Exit";
 const ARENA_SWAP: &str = "::emojicoin_arena::Swap";
 const ARENA_VAULT_BALANCE_UPDATE: &str = "::emojicoin_arena::VaultBalanceUpdate";
+pub const CANDLESTICK_DECIMALS: NonZeroU64 = NonZeroU64::new(16).unwrap();
 
 lazy_static! {
     pub static ref MODULE_ADDRESS: String = std::env::var("EMOJICOIN_MODULE_ADDRESS")

--- a/rust/processor/src/db/common/models/emojicoin_models/enums.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/enums.rs
@@ -189,6 +189,8 @@ pub enum EmojicoinDbEvent {
     ArenaExit(ArenaExitEventModel),
     ArenaSwap(ArenaSwapEventModel),
     ArenaVaultBalanceUpdate(ArenaVaultBalanceUpdateEventModel),
+    // Not an actual event in the contract- but is sent to the broker.
+    ArenaCandlestick(ArenaCandlestickModel),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -221,6 +223,8 @@ pub enum EmojicoinDbEventType {
     ArenaExit,
     ArenaSwap,
     ArenaVaultBalanceUpdate,
+    // Not an actual event in the contract- but is sent to the broker.
+    ArenaCandlestick,
 }
 
 impl From<&EmojicoinEvent> for EmojicoinEventType {
@@ -261,6 +265,7 @@ impl From<&EmojicoinDbEvent> for EmojicoinDbEventType {
             EmojicoinDbEvent::ArenaExit(_) => Self::ArenaExit,
             EmojicoinDbEvent::ArenaSwap(_) => Self::ArenaSwap,
             EmojicoinDbEvent::ArenaVaultBalanceUpdate(_) => Self::ArenaVaultBalanceUpdate,
+            EmojicoinDbEvent::ArenaCandlestick(_) => Self::ArenaCandlestick,
         }
     }
 }
@@ -351,6 +356,14 @@ impl EmojicoinDbEvent {
             .iter()
             .cloned()
             .map(Self::ArenaVaultBalanceUpdate)
+            .collect()
+    }
+
+    pub fn from_arena_candlesticks(candlesticks: &[ArenaCandlestickModel]) -> Vec<Self> {
+        candlesticks
+            .iter()
+            .cloned()
+            .map(Self::ArenaCandlestick)
             .collect()
     }
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlestick.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlestick.rs
@@ -1,5 +1,8 @@
 use crate::{
-    db::common::models::emojicoin_models::{enums::Period, json_types::StateEvent},
+    db::common::models::emojicoin_models::{
+        enums::Period,
+        json_types::{StateEvent, TxnInfo},
+    },
     schema::arena_candlestick,
 };
 use bigdecimal::BigDecimal;
@@ -12,6 +15,7 @@ use std::collections::HashMap;
 #[derive(Clone)]
 pub struct ArenaCandlestickDiffModelBuilder {
     pub melee_id: BigDecimal,
+    pub last_transaction_version: i64,
 
     pub period: Period,
     pub start_time: NaiveDateTime,
@@ -37,6 +41,8 @@ impl ArenaCandlestickDiffModelBuilder {
             sticks_map
                 .entry((stick.melee_id.clone(), stick.period, stick.start_time))
                 .and_modify(|s| {
+                    s.last_transaction_version =
+                        std::cmp::max(s.last_transaction_version, stick.last_transaction_version);
                     s.volume += stick.volume;
                     s.n_swaps += stick.n_swaps;
                     s.high_price = BigDecimal::max(s.high_price.clone(), stick.high_price);
@@ -57,9 +63,9 @@ impl ArenaCandlestickDiffModelBuilder {
     }
 
     pub fn from_state_event(
+        txn_info: &TxnInfo,
         melee_id: BigDecimal,
         state: StateEvent,
-        transaction_timestamp: NaiveDateTime,
         swap_timestamp: (i64, i64),
         price_0: BigDecimal,
         price_1: BigDecimal,
@@ -76,12 +82,14 @@ impl ArenaCandlestickDiffModelBuilder {
         let mut candlesticks: Vec<Self> = vec![];
 
         for period in periods {
-            let start_time = transaction_timestamp
+            let start_time = txn_info
+                .timestamp
                 .duration_trunc(period.to_time_delta())
                 .unwrap();
             let price = price_0.clone() / price_1.clone();
             let x = Self {
                 melee_id: melee_id.clone(),
+                last_transaction_version: txn_info.version,
                 period,
                 start_time,
                 open_price: price.clone(),
@@ -103,6 +111,7 @@ impl ArenaCandlestickDiffModelBuilder {
 #[diesel(table_name = arena_candlestick)]
 pub struct ArenaCandlestickDiffModel {
     pub melee_id: BigDecimal,
+    pub last_transaction_version: i64,
 
     pub period: Period,
     pub start_time: NaiveDateTime,
@@ -119,6 +128,7 @@ impl From<ArenaCandlestickDiffModelBuilder> for ArenaCandlestickDiffModel {
     fn from(value: ArenaCandlestickDiffModelBuilder) -> Self {
         Self {
             melee_id: value.melee_id,
+            last_transaction_version: value.last_transaction_version,
 
             period: value.period,
             start_time: value.start_time,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlesticks.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlesticks.rs
@@ -1,11 +1,12 @@
 use crate::{
     db::common::models::emojicoin_models::{
+        constants::CANDLESTICK_DECIMALS,
         enums::Period,
         json_types::{StateEvent, TxnInfo},
     },
-    schema::arena_candlestick,
+    schema::arena_candlesticks,
 };
-use bigdecimal::BigDecimal;
+use bigdecimal::{BigDecimal, RoundingMode};
 use chrono::{DurationRound, NaiveDateTime};
 use field_count::FieldCount;
 use num::FromPrimitive;
@@ -108,8 +109,8 @@ impl ArenaCandlestickDiffModelBuilder {
 }
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(melee_id, period, start_time))]
-#[diesel(table_name = arena_candlestick)]
-pub struct ArenaCandlestickDiffModel {
+#[diesel(table_name = arena_candlesticks)]
+pub struct ArenaCandlestickModel {
     pub melee_id: BigDecimal,
     pub last_transaction_version: i64,
 
@@ -124,7 +125,13 @@ pub struct ArenaCandlestickDiffModel {
     pub n_swaps: BigDecimal,
 }
 
-impl From<ArenaCandlestickDiffModelBuilder> for ArenaCandlestickDiffModel {
+impl ArenaCandlestickModel {
+    fn truncate(value: BigDecimal) -> BigDecimal {
+        value.with_precision_round(CANDLESTICK_DECIMALS, RoundingMode::HalfEven)
+    }
+}
+
+impl From<ArenaCandlestickDiffModelBuilder> for ArenaCandlestickModel {
     fn from(value: ArenaCandlestickDiffModelBuilder) -> Self {
         Self {
             melee_id: value.melee_id,
@@ -133,10 +140,10 @@ impl From<ArenaCandlestickDiffModelBuilder> for ArenaCandlestickDiffModel {
             period: value.period,
             start_time: value.start_time,
 
-            open_price: value.open_price,
-            high_price: value.high_price,
-            low_price: value.low_price,
-            close_price: value.close_price,
+            open_price: Self::truncate(value.open_price),
+            high_price: Self::truncate(value.high_price),
+            low_price: Self::truncate(value.low_price),
+            close_price: Self::truncate(value.close_price),
 
             volume: value.volume,
             n_swaps: value.n_swaps,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_info.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_info.rs
@@ -2,7 +2,10 @@ use super::{
     arena_enter_event::ArenaEnterEventModel, arena_exit_event::ArenaExitEventModel,
     arena_melee_event::ArenaMeleeEventModel, arena_swap_event::ArenaSwapEventModel,
 };
-use crate::{db::common::models::emojicoin_models::json_types::StateEvent, schema::arena_info};
+use crate::{
+    db::common::models::emojicoin_models::json_types::{StateEvent, TxnInfo},
+    schema::arena_info,
+};
 use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use num::Zero;
@@ -14,6 +17,7 @@ use std::collections::HashMap;
 #[diesel(table_name = arena_info)]
 pub struct ArenaInfoModel {
     pub melee_id: BigDecimal,
+    pub last_transaction_version: i64,
     pub volume: BigDecimal,
     pub rewards_remaining: BigDecimal,
     pub emojicoin_0_locked: BigDecimal,
@@ -41,6 +45,7 @@ pub struct ArenaInfoData {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ArenaInfoDiffUpdate {
     pub melee_id: BigDecimal,
+    pub last_transaction_version: i64,
     pub volume: BigDecimal,
     pub rewards_remaining: BigDecimal,
     pub emojicoin_0_locked: BigDecimal,
@@ -48,9 +53,14 @@ pub struct ArenaInfoDiffUpdate {
 }
 
 impl ArenaInfoModel {
-    pub fn new(arena_melee_event: ArenaMeleeEventModel, data: ArenaInfoData) -> ArenaInfoModel {
+    pub fn new(
+        txn_info: &TxnInfo,
+        arena_melee_event: ArenaMeleeEventModel,
+        data: ArenaInfoData,
+    ) -> ArenaInfoModel {
         ArenaInfoModel {
             melee_id: arena_melee_event.melee_id,
+            last_transaction_version: txn_info.version,
             volume: BigDecimal::zero(),
             rewards_remaining: arena_melee_event.available_rewards,
             emojicoin_0_locked: BigDecimal::zero(),
@@ -74,6 +84,7 @@ impl From<ArenaEnterEventModel> for ArenaInfoDiffUpdate {
     fn from(value: ArenaEnterEventModel) -> Self {
         Self {
             melee_id: value.melee_id,
+            last_transaction_version: value.transaction_version,
             volume: value.quote_volume.clone(),
             rewards_remaining: -value.match_amount,
             emojicoin_0_locked: value.emojicoin_0_proceeds,
@@ -90,6 +101,7 @@ impl ArenaInfoDiffUpdate {
     ) -> Self {
         Self {
             melee_id: value.melee_id,
+            last_transaction_version: value.transaction_version,
             volume: value.quote_volume,
             rewards_remaining: BigDecimal::zero(),
             emojicoin_0_locked: emojicoin_0.last_swap.base_volume.clone()
@@ -103,6 +115,7 @@ impl From<ArenaExitEventModel> for ArenaInfoDiffUpdate {
     fn from(value: ArenaExitEventModel) -> Self {
         Self {
             melee_id: value.melee_id,
+            last_transaction_version: value.transaction_version,
             volume: BigDecimal::zero(),
             rewards_remaining: -value.tap_out_fee,
             emojicoin_0_locked: -value.emojicoin_0_proceeds,
@@ -117,6 +130,8 @@ impl ArenaInfoDiffUpdate {
         for value in values {
             map.entry(value.melee_id.clone())
                 .and_modify(|a| {
+                    a.last_transaction_version =
+                        std::cmp::max(a.last_transaction_version, value.last_transaction_version);
                     a.volume += value.volume.clone();
                     a.rewards_remaining += value.rewards_remaining.clone();
                     a.emojicoin_0_locked += value.emojicoin_0_locked.clone();

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_leaderboard_history.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_leaderboard_history.rs
@@ -5,16 +5,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ArenaLeaderboardHistoryPartialModel {
     pub melee_id: BigDecimal,
+    pub last_transaction_version: i64,
 
     pub emojicoin_0_price: BigDecimal,
     pub emojicoin_1_price: BigDecimal,
 }
 
 impl ArenaLeaderboardHistoryPartialModel {
-    pub fn new(melee_data: &MeleeData) -> ArenaLeaderboardHistoryPartialModel {
+    pub fn new(
+        melee_data: &MeleeData,
+        last_transaction_version: i64,
+    ) -> ArenaLeaderboardHistoryPartialModel {
         ArenaLeaderboardHistoryPartialModel {
             melee_id: melee_data.melee_id.clone(),
-
+            last_transaction_version,
             emojicoin_0_price: melee_data.price_0.clone(),
             emojicoin_1_price: melee_data.price_1.clone(),
         }

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_position.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_position.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::common::models::emojicoin_models::json_types::{
-        ArenaEnterEvent, ArenaExitEvent, ArenaSwapEvent, StateEvent,
+        ArenaEnterEvent, ArenaExitEvent, ArenaSwapEvent, StateEvent, TxnInfo,
     },
     schema::arena_position,
 };
@@ -44,6 +44,7 @@ use std::collections::HashMap;
 /// outdated data.
 pub struct ArenaPositionDiffModel {
     pub user: String,
+    pub last_transaction_version: i64,
     pub melee_id: BigDecimal,
     pub open: bool,
     pub emojicoin_0_balance: BigDecimal,
@@ -54,10 +55,14 @@ pub struct ArenaPositionDiffModel {
     pub last_exit_0: Option<bool>,
 }
 
-impl From<ArenaEnterEvent> for ArenaPositionDiffModel {
-    fn from(arena_enter_event: ArenaEnterEvent) -> ArenaPositionDiffModel {
+impl ArenaPositionDiffModel {
+    pub fn from_enter(
+        txn_info: &TxnInfo,
+        arena_enter_event: ArenaEnterEvent,
+    ) -> ArenaPositionDiffModel {
         ArenaPositionDiffModel {
             user: arena_enter_event.user,
+            last_transaction_version: txn_info.version,
             melee_id: arena_enter_event.melee_id,
             open: true,
             emojicoin_0_balance: arena_enter_event.emojicoin_0_proceeds,
@@ -68,16 +73,40 @@ impl From<ArenaEnterEvent> for ArenaPositionDiffModel {
             last_exit_0: None,
         }
     }
-}
 
-impl ArenaPositionDiffModel {
+    pub fn from_exit(
+        txn_info: &TxnInfo,
+        arena_exit_event: ArenaExitEvent,
+    ) -> ArenaPositionDiffModel {
+        ArenaPositionDiffModel {
+            user: arena_exit_event.user,
+            last_transaction_version: txn_info.version,
+            melee_id: arena_exit_event.melee_id,
+            open: false,
+            emojicoin_0_balance: -arena_exit_event.emojicoin_0_proceeds.clone(),
+            emojicoin_1_balance: -arena_exit_event.emojicoin_1_proceeds.clone(),
+            withdrawals: (arena_exit_event.emojicoin_0_proceeds
+                / arena_exit_event.emojicoin_0_exchange_rate.base
+                * arena_exit_event.emojicoin_0_exchange_rate.quote
+                + arena_exit_event.emojicoin_1_proceeds.clone()
+                    / arena_exit_event.emojicoin_1_exchange_rate.base
+                    * arena_exit_event.emojicoin_1_exchange_rate.quote)
+                .round(0),
+            deposits: BigDecimal::zero(),
+            match_amount: -arena_exit_event.tap_out_fee,
+            last_exit_0: Some(arena_exit_event.emojicoin_1_proceeds.is_zero()),
+        }
+    }
+
     pub fn from_swap(
+        txn_info: &TxnInfo,
         arena_swap_event: ArenaSwapEvent,
         emojicoin_0: &StateEvent,
         emojicoin_1: &StateEvent,
     ) -> ArenaPositionDiffModel {
         ArenaPositionDiffModel {
             user: arena_swap_event.user,
+            last_transaction_version: txn_info.version,
             melee_id: arena_swap_event.melee_id,
             open: true,
             emojicoin_0_balance: emojicoin_0.last_swap.base_volume.clone()
@@ -97,6 +126,10 @@ impl ArenaPositionDiffModel {
             let position_clone = position.clone();
             map.entry((position.melee_id, position.user))
                 .and_modify(|p| {
+                    p.last_transaction_version = std::cmp::max(
+                        p.last_transaction_version,
+                        position.last_transaction_version,
+                    );
                     p.open = position.open;
                     p.emojicoin_0_balance += position.emojicoin_0_balance;
                     p.emojicoin_1_balance += position.emojicoin_1_balance;
@@ -108,27 +141,5 @@ impl ArenaPositionDiffModel {
                 .or_insert(position_clone);
         }
         map.into_values().collect()
-    }
-}
-
-impl From<ArenaExitEvent> for ArenaPositionDiffModel {
-    fn from(arena_exit_event: ArenaExitEvent) -> ArenaPositionDiffModel {
-        ArenaPositionDiffModel {
-            user: arena_exit_event.user,
-            melee_id: arena_exit_event.melee_id,
-            open: false,
-            emojicoin_0_balance: -arena_exit_event.emojicoin_0_proceeds.clone(),
-            emojicoin_1_balance: -arena_exit_event.emojicoin_1_proceeds.clone(),
-            withdrawals: (arena_exit_event.emojicoin_0_proceeds
-                / arena_exit_event.emojicoin_0_exchange_rate.base
-                * arena_exit_event.emojicoin_0_exchange_rate.quote
-                + arena_exit_event.emojicoin_1_proceeds.clone()
-                    / arena_exit_event.emojicoin_1_exchange_rate.base
-                    * arena_exit_event.emojicoin_1_exchange_rate.quote)
-                .round(0),
-            deposits: BigDecimal::zero(),
-            match_amount: -arena_exit_event.tap_out_fee,
-            last_exit_0: Some(arena_exit_event.emojicoin_1_proceeds.is_zero()),
-        }
     }
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/models/market_1m_periods_in_last_day.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/market_1m_periods_in_last_day.rs
@@ -1,15 +1,15 @@
 use super::market_24h_rolling_volume::RecentOneMinutePeriodicStateEvent;
-use crate::{
-    schema::{self, market_1m_periods_in_last_day},
-    utils::database::ArcDbPool,
-};
+use crate::schema::{self, market_1m_periods_in_last_day};
 use bigdecimal::BigDecimal;
 use chrono::NaiveDateTime;
 use diesel::{
     dsl::{now, IntervalDsl},
     result::Error,
 };
-use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection};
+use diesel_async::{
+    pooled_connection::bb8::PooledConnection, scoped_futures::ScopedFutureExt, AsyncConnection,
+    AsyncPgConnection,
+};
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
@@ -40,25 +40,17 @@ impl From<RecentOneMinutePeriodicStateEvent> for MarketOneMinutePeriodsInLastDay
 
 impl MarketOneMinutePeriodsInLastDayModel {
     pub async fn insert_and_delete_periods(
-        items: &[MarketOneMinutePeriodsInLastDayModel],
-        pool: ArcDbPool,
+        items: Vec<MarketOneMinutePeriodsInLastDayModel>,
+        conn: &mut PooledConnection<'_, AsyncPgConnection>,
     ) -> Result<(), diesel::result::Error> {
         use diesel::prelude::*;
         use schema::market_1m_periods_in_last_day::dsl::*;
-
-        let conn = &mut pool.get().await.map_err(|e| {
-            tracing::warn!("Error getting connection from pool: {:?}", e);
-            diesel::result::Error::DatabaseError(
-                diesel::result::DatabaseErrorKind::UnableToSendCommand,
-                Box::new(e.to_string()),
-            )
-        })?;
 
         conn.transaction::<_, Error, _>(|conn| {
             async move {
                 let inserted = diesel_async::RunQueryDsl::execute(
                     diesel::insert_into(schema::market_1m_periods_in_last_day::table)
-                        .values(items)
+                        .values(&items)
                         .on_conflict((market_id, nonce))
                         .do_nothing(),
                     conn,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/mod.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/mod.rs
@@ -1,4 +1,4 @@
-pub mod arena_candlestick;
+pub mod arena_candlesticks;
 pub mod arena_enter_event;
 pub mod arena_exit_event;
 pub mod arena_info;
@@ -20,7 +20,7 @@ pub mod user_liquidity_pools;
 
 pub mod prelude {
     pub use super::{
-        arena_candlestick::*, arena_enter_event::*, arena_exit_event::*, arena_info::*,
+        arena_candlesticks::*, arena_enter_event::*, arena_exit_event::*, arena_info::*,
         arena_leaderboard_history::*, arena_melee_event::*, arena_position::*, arena_swap_event::*,
         arena_vault_balance_update_event::*, chat_event::*, global_state_event::*,
         liquidity_event::*, market_1m_periods_in_last_day::*, market_24h_rolling_volume::*,

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
@@ -250,7 +250,7 @@ pub fn insert_arena_position_query(
                     "COALESCE(EXCLUDED.last_exit_0, arena_position.last_exit_0)",
                 )),
             )),
-        None,
+        Some(" WHERE arena_position.last_transaction_version <= excluded.last_transaction_version"),
     )
 }
 
@@ -279,7 +279,7 @@ pub fn insert_arena_info_query(
                 max_match_percentage.eq(excluded(max_match_percentage)),
                 max_match_amount.eq(excluded(max_match_amount)),
             )),
-        None,
+        Some(" WHERE arena_info.last_transaction_version <= excluded.last_transaction_version"),
     )
 }
 
@@ -295,6 +295,7 @@ pub fn update_arena_info_query(
         .map(|i| {
             (
                 melee_id.eq(i.melee_id),
+                last_transaction_version.eq(i.last_transaction_version),
                 volume.eq(i.volume.clone()),
                 rewards_remaining.eq(i.rewards_remaining),
                 emojicoin_0_locked.eq(i.emojicoin_0_locked),
@@ -309,11 +310,12 @@ pub fn update_arena_info_query(
             .do_update()
             .set((
                 volume.eq(volume + excluded(volume)),
+                last_transaction_version.eq(excluded(last_transaction_version)),
                 rewards_remaining.eq(rewards_remaining + excluded(rewards_remaining)),
                 emojicoin_0_locked.eq(emojicoin_0_locked + excluded(emojicoin_0_locked)),
                 emojicoin_1_locked.eq(emojicoin_1_locked + excluded(emojicoin_1_locked)),
             )),
-        None,
+        Some(" WHERE arena_info.last_transaction_version <= excluded.last_transaction_version"),
     )
 }
 
@@ -353,6 +355,7 @@ pub fn update_arena_leaderboard_history_query(
     diesel::update(arena_leaderboard_history)
         .filter(melee_id.eq(exit.melee_id))
         .filter(user.eq(exit.user))
+        .filter(last_transaction_version.le(exit.transaction_version))
         .set((
             exited.eq(true),
             last_exit_0.eq(exit.emojicoin_1_proceeds.is_zero()),
@@ -436,6 +439,7 @@ pub fn insert_arena_candlesticks_query(
             .on_conflict((melee_id, period, start_time))
             .do_update()
             .set((
+                last_transaction_version.eq(excluded(last_transaction_version)),
                 open_price.eq(sql("COALESCE(")
                     .bind(open_price)
                     .sql(",")
@@ -459,6 +463,8 @@ pub fn insert_arena_candlesticks_query(
                 volume.eq(volume + excluded(volume)),
                 n_swaps.eq(n_swaps + excluded(n_swaps)),
             )),
-        None,
+        // Not less than or equal to, just less than, because this query aggregates, it shouldn't
+        // ever run twice. Ideally, candlesticks here would be filtered already.
+        Some(" WHERE arena_candlestick.last_transaction_version < excluded.last_transaction_version "),
     )
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
@@ -17,12 +17,8 @@ pub fn insert_chat_events_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::chat_events::dsl::*;
     (
-        diesel::insert_into(schema::chat_events::table)
-            .values(items_to_insert)
-            .on_conflict((market_id, market_nonce))
-            .do_nothing(),
+        diesel::insert_into(schema::chat_events::table).values(items_to_insert),
         None,
     )
 }
@@ -33,12 +29,8 @@ pub fn insert_liquidity_events_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::liquidity_events::dsl::*;
     (
-        diesel::insert_into(schema::liquidity_events::table)
-            .values(items_to_insert)
-            .on_conflict((market_id, market_nonce))
-            .do_nothing(),
+        diesel::insert_into(schema::liquidity_events::table).values(items_to_insert),
         None,
     )
 }
@@ -49,12 +41,8 @@ pub fn insert_swap_events_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::swap_events::dsl::*;
     (
-        diesel::insert_into(schema::swap_events::table)
-            .values(items_to_insert)
-            .on_conflict((market_id, market_nonce))
-            .do_nothing(),
+        diesel::insert_into(schema::swap_events::table).values(items_to_insert),
         None,
     )
 }
@@ -65,12 +53,8 @@ pub fn insert_market_registration_events_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::market_registration_events::dsl::*;
     (
-        diesel::insert_into(schema::market_registration_events::table)
-            .values(items_to_insert)
-            .on_conflict(market_id)
-            .do_nothing(),
+        diesel::insert_into(schema::market_registration_events::table).values(items_to_insert),
         None,
     )
 }
@@ -98,12 +82,8 @@ pub fn insert_periodic_state_events_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::periodic_state_events::dsl::*;
     (
-        diesel::insert_into(schema::periodic_state_events::table)
-            .values(items_to_insert)
-            .on_conflict((market_id, period, market_nonce))
-            .do_nothing(),
+        diesel::insert_into(schema::periodic_state_events::table).values(items_to_insert),
         None,
     )
 }
@@ -114,12 +94,8 @@ pub fn insert_global_events(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::global_state_events::dsl::*;
     (
-        diesel::insert_into(schema::global_state_events::table)
-            .values(items_to_insert)
-            .on_conflict(registry_nonce)
-            .do_nothing(),
+        diesel::insert_into(schema::global_state_events::table).values(items_to_insert),
         None,
     )
 }
@@ -217,12 +193,8 @@ pub fn insert_arena_melee_events_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::arena_melee_events::dsl::*;
     (
-        diesel::insert_into(schema::arena_melee_events::table)
-            .values(items_to_insert)
-            .on_conflict(melee_id)
-            .do_nothing(),
+        diesel::insert_into(schema::arena_melee_events::table).values(items_to_insert),
         None,
     )
 }
@@ -241,6 +213,7 @@ pub fn insert_arena_position_query(
             .do_update()
             .set((
                 open.eq(excluded(open)),
+                last_transaction_version.eq(excluded(last_transaction_version)),
                 emojicoin_0_balance.eq(emojicoin_0_balance + excluded(emojicoin_0_balance)),
                 emojicoin_1_balance.eq(emojicoin_1_balance + excluded(emojicoin_1_balance)),
                 deposits.eq(deposits + excluded(deposits)),
@@ -250,7 +223,7 @@ pub fn insert_arena_position_query(
                     "COALESCE(EXCLUDED.last_exit_0, arena_position.last_exit_0)",
                 )),
             )),
-        Some(" WHERE arena_position.last_transaction_version <= excluded.last_transaction_version"),
+        None,
     )
 }
 
@@ -267,6 +240,7 @@ pub fn insert_arena_info_query(
             .on_conflict(melee_id)
             .do_update()
             .set((
+                last_transaction_version.eq(excluded(last_transaction_version)),
                 rewards_remaining.eq(rewards_remaining + excluded(rewards_remaining)),
                 emojicoin_0_market_address.eq(excluded(emojicoin_0_market_address)),
                 emojicoin_1_market_address.eq(excluded(emojicoin_1_market_address)),
@@ -279,7 +253,7 @@ pub fn insert_arena_info_query(
                 max_match_percentage.eq(excluded(max_match_percentage)),
                 max_match_amount.eq(excluded(max_match_amount)),
             )),
-        Some(" WHERE arena_info.last_transaction_version <= excluded.last_transaction_version"),
+        None,
     )
 }
 
@@ -315,7 +289,7 @@ pub fn update_arena_info_query(
                 emojicoin_0_locked.eq(emojicoin_0_locked + excluded(emojicoin_0_locked)),
                 emojicoin_1_locked.eq(emojicoin_1_locked + excluded(emojicoin_1_locked)),
             )),
-        Some(" WHERE arena_info.last_transaction_version <= excluded.last_transaction_version"),
+        None,
     )
 }
 
@@ -326,10 +300,10 @@ pub fn insert_arena_leaderboard_history_query(
 
     // See header comment of leaderboard.sql for more information on query parameters.
 
-    // $1 is the melee_id
+    // $1 is the melee_id.
     query = query.replace("$1", &arena_leaderboard_history_model.melee_id.to_string());
 
-    // $2 is the curve price of emojicoin_0
+    // $2 is the curve price of emojicoin_0.
     query = query.replace(
         "$2",
         &arena_leaderboard_history_model
@@ -337,11 +311,19 @@ pub fn insert_arena_leaderboard_history_query(
             .to_string(),
     );
 
-    // $3 is the curve price of emojicoin_1
+    // $3 is the curve price of emojicoin_1.
     query = query.replace(
         "$3",
         &arena_leaderboard_history_model
             .emojicoin_1_price
+            .to_string(),
+    );
+
+    // $4 is the transaction version of this snapshot; i.e., when this melee ended.
+    query = query.replace(
+        "$4",
+        &arena_leaderboard_history_model
+            .last_transaction_version
             .to_string(),
     );
 
@@ -355,9 +337,9 @@ pub fn update_arena_leaderboard_history_query(
     diesel::update(arena_leaderboard_history)
         .filter(melee_id.eq(exit.melee_id))
         .filter(user.eq(exit.user))
-        .filter(last_transaction_version.le(exit.transaction_version))
         .set((
             exited.eq(true),
+            last_transaction_version.eq(exit.transaction_version),
             last_exit_0.eq(exit.emojicoin_1_proceeds.is_zero()),
         ))
 }
@@ -368,12 +350,8 @@ pub fn insert_arena_enter_events_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::arena_enter_events::dsl::*;
     (
-        diesel::insert_into(schema::arena_enter_events::table)
-            .values(items_to_insert)
-            .on_conflict((transaction_version, event_index))
-            .do_nothing(),
+        diesel::insert_into(schema::arena_enter_events::table).values(items_to_insert),
         None,
     )
 }
@@ -384,12 +362,8 @@ pub fn insert_arena_exit_events_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::arena_exit_events::dsl::*;
     (
-        diesel::insert_into(schema::arena_exit_events::table)
-            .values(items_to_insert)
-            .on_conflict((transaction_version, event_index))
-            .do_nothing(),
+        diesel::insert_into(schema::arena_exit_events::table).values(items_to_insert),
         None,
     )
 }
@@ -400,12 +374,8 @@ pub fn insert_arena_swap_events_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::arena_swap_events::dsl::*;
     (
-        diesel::insert_into(schema::arena_swap_events::table)
-            .values(items_to_insert)
-            .on_conflict((transaction_version, event_index))
-            .do_nothing(),
+        diesel::insert_into(schema::arena_swap_events::table).values(items_to_insert),
         None,
     )
 }
@@ -416,25 +386,22 @@ pub fn insert_arena_vault_balance_update_events_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::arena_vault_balance_update_events::dsl::*;
     (
         diesel::insert_into(schema::arena_vault_balance_update_events::table)
-            .values(items_to_insert)
-            .on_conflict((transaction_version, event_index))
-            .do_nothing(),
+            .values(items_to_insert),
         None,
     )
 }
 
 pub fn insert_arena_candlesticks_query(
-    items_to_insert: Vec<ArenaCandlestickDiffModel>,
+    items_to_insert: Vec<ArenaCandlestickModel>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::arena_candlestick::dsl::*;
+    use schema::arena_candlesticks::dsl::*;
     (
-        diesel::insert_into(schema::arena_candlestick::table)
+        diesel::insert_into(schema::arena_candlesticks::table)
             .values(items_to_insert)
             .on_conflict((melee_id, period, start_time))
             .do_update()
@@ -465,6 +432,6 @@ pub fn insert_arena_candlesticks_query(
             )),
         // Not less than or equal to, just less than, because this query aggregates, it shouldn't
         // ever run twice. Ideally, candlesticks here would be filtered already.
-        Some(" WHERE arena_candlestick.last_transaction_version < excluded.last_transaction_version "),
+        None,
     )
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/leaderboard.sql
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/leaderboard.sql
@@ -11,9 +11,11 @@
 -- $1: the melee_id for which to calculate the leaderboard
 -- $2: the curve price of emojicoin_0 at the end of the melee
 -- $3: the curve price of emojicoin_1 at the end of the melee
+-- $4: the transaction version of the snapshot; i.e., when this melee ended
 
 INSERT INTO arena_leaderboard_history (
     "user",
+    last_transaction_version,
     melee_id,
     profits,
     losses,
@@ -82,6 +84,7 @@ last_balances AS (
 )
 SELECT
     position."user",
+    $4 AS last_transaction_version,
     $1 AS melee_id,
     -- Profits = Withdrawals in APT + current emojicoin balance converted to APT.
     COALESCE(withdrawals, 0) +
@@ -109,6 +112,4 @@ SELECT
     COALESCE(withdrawals, 0) AS withdrawals
 FROM position
     NATURAL INNER JOIN last_balances
-    NATURAL LEFT JOIN withdrawals
-ON CONFLICT
-DO NOTHING;
+    NATURAL LEFT JOIN withdrawals;

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/down.sql
@@ -9,4 +9,6 @@ DROP TABLE arena_vault_balance_update_events ;
 DROP TABLE arena_position ;
 DROP TABLE arena_leaderboard_history ;
 DROP TABLE arena_info ;
-DROP TABLE arena_candlestick ;
+DROP TABLE arena_candlesticks ;
+
+DROP TABLE emojicoin_last_processed_transaction ;

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
@@ -156,7 +156,7 @@ CREATE TABLE arena_info (
     max_match_amount NUMERIC
 );
 
-CREATE TABLE arena_candlestick (
+CREATE TABLE arena_candlesticks (
     melee_id NUMERIC NOT NULL,
     last_transaction_version BIGINT NOT NULL,
 
@@ -235,3 +235,8 @@ ON
     arena_info.melee_id = arena_leaderboard_history.melee_id;
 
 ALTER TYPE period_type ADD VALUE IF NOT EXISTS 'period_15s';
+
+CREATE TABLE emojicoin_last_processed_transaction (
+    id BIGINT NOT NULL PRIMARY KEY,
+    version BIGINT NOT NULL
+);

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
@@ -107,6 +107,7 @@ CREATE TABLE arena_vault_balance_update_events (
 
 CREATE TABLE arena_position (
     "user" TEXT NOT NULL,
+    last_transaction_version BIGINT NOT NULL,
     melee_id NUMERIC NOT NULL,
     open BOOL NOT NULL,
     emojicoin_0_balance NUMERIC NOT NULL,
@@ -121,6 +122,7 @@ CREATE TABLE arena_position (
 
 CREATE TABLE arena_leaderboard_history (
     "user" TEXT NOT NULL,
+    last_transaction_version BIGINT NOT NULL,
     melee_id NUMERIC NOT NULL,
     profits NUMERIC NOT NULL,
     losses NUMERIC NOT NULL,
@@ -135,6 +137,7 @@ CREATE TABLE arena_leaderboard_history (
 
 CREATE TABLE arena_info (
     melee_id NUMERIC NOT NULL PRIMARY KEY,
+    last_transaction_version BIGINT NOT NULL,
     volume NUMERIC NOT NULL,
     rewards_remaining NUMERIC NOT NULL,
     emojicoin_0_locked NUMERIC NOT NULL,
@@ -155,6 +158,7 @@ CREATE TABLE arena_info (
 
 CREATE TABLE arena_candlestick (
     melee_id NUMERIC NOT NULL,
+    last_transaction_version BIGINT NOT NULL,
 
     period period_type NOT NULL,
     start_time TIMESTAMP NOT NULL,

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -98,7 +98,7 @@ diesel::table! {
     use diesel::sql_types::*;
     use super::sql_types::PeriodType;
 
-    arena_candlestick (melee_id, period, start_time) {
+    arena_candlesticks (melee_id, period, start_time) {
         melee_id -> Numeric,
         last_transaction_version -> Int8,
         period -> PeriodType,
@@ -978,6 +978,13 @@ diesel::table! {
 }
 
 diesel::table! {
+    emojicoin_last_processed_transaction (id) {
+        id -> Int8,
+        version -> Int8,
+    }
+}
+
+diesel::table! {
     emojis (emoji) {
         emoji -> Bytea,
     }
@@ -1840,7 +1847,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     ans_lookup_v2,
     ans_primary_name,
     ans_primary_name_v2,
-    arena_candlestick,
+    arena_candlesticks,
     arena_enter_events,
     arena_exit_events,
     arena_info,
@@ -1883,6 +1890,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     delegated_staking_pool_balances,
     delegated_staking_pools,
     delegator_balances,
+    emojicoin_last_processed_transaction,
     emojis,
     event_size_info,
     events,

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -100,6 +100,7 @@ diesel::table! {
 
     arena_candlestick (melee_id, period, start_time) {
         melee_id -> Numeric,
+        last_transaction_version -> Int8,
         period -> PeriodType,
         start_time -> Timestamp,
         open_price -> Nullable<Numeric>,
@@ -163,6 +164,7 @@ diesel::table! {
 diesel::table! {
     arena_info (melee_id) {
         melee_id -> Numeric,
+        last_transaction_version -> Int8,
         volume -> Numeric,
         rewards_remaining -> Numeric,
         emojicoin_0_locked -> Numeric,
@@ -183,6 +185,7 @@ diesel::table! {
 diesel::table! {
     arena_leaderboard_history (user, melee_id) {
         user -> Text,
+        last_transaction_version -> Int8,
         melee_id -> Numeric,
         profits -> Numeric,
         losses -> Numeric,
@@ -218,6 +221,7 @@ diesel::table! {
 diesel::table! {
     arena_position (user, melee_id) {
         user -> Text,
+        last_transaction_version -> Int8,
         melee_id -> Numeric,
         open -> Bool,
         emojicoin_0_balance -> Numeric,

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -17,7 +17,10 @@ use crate::{
     schema,
     utils::{
         counters::PROCESSOR_UNKNOWN_TYPE_COUNT,
-        database::{execute_in_chunks, execute_single, get_config_table_chunk_size, ArcDbPool},
+        database::{
+            execute_in_transaction, execute_single_transaction, get_config_table_chunk_size,
+            ArcDbPool,
+        },
         util::{
             bigdecimal_to_u64, get_entry_function_from_user_request, parse_timestamp,
             standardize_address,
@@ -29,9 +32,8 @@ use anyhow::{bail, Context};
 use aptos_protos::transaction::v1::{transaction::TxnData, Transaction};
 use async_trait::async_trait;
 use bigdecimal::BigDecimal;
-use diesel::{ExpressionMethods as _, QueryDsl as _};
-use diesel_async::RunQueryDsl;
-use futures::{future::try_join_all, FutureExt};
+use diesel::{upsert::excluded, ExpressionMethods as _, QueryDsl as _};
+use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection, RunQueryDsl};
 use itertools::Itertools;
 use num::Zero;
 use std::{fmt::Debug, sync::Arc};
@@ -51,6 +53,69 @@ pub struct EmojicoinProcessor {
     per_table_chunk_sizes: AHashMap<String, usize>,
     notif_sender: UnboundedSender<EmojicoinDbEvent>,
     melee_data: Arc<RwLock<Option<MeleeData>>>,
+    version: Arc<RwLock<u64>>,
+}
+
+/// Gets MeleeData from the database.
+async fn get_melee_data_from_db(connection_pool: ArcDbPool) -> anyhow::Result<Option<MeleeData>> {
+    if ARENA_MODULE_ADDRESS.is_none() {
+        return Ok::<Option<MeleeData>, anyhow::Error>(None);
+    }
+    let conn = &mut connection_pool.get().await?;
+    let melee = {
+        use schema::arena_info::dsl::*;
+        let melee = arena_info
+            .select((melee_id, emojicoin_0_market_id, emojicoin_1_market_id))
+            .order(melee_id.desc())
+            .limit(1)
+            .get_results::<(BigDecimal, Option<BigDecimal>, Option<BigDecimal>)>(conn)
+            .await?;
+        melee.as_slice().first().cloned()
+    };
+    if melee.is_none() {
+        return Ok::<Option<MeleeData>, anyhow::Error>(None);
+    }
+    let (melee_id, market_id_0, market_id_1) = melee.unwrap();
+    let (market_id_0, market_id_1) = (market_id_0.unwrap(), market_id_1.unwrap());
+    let (price_0, price_1) = {
+        use schema::market_latest_state_event::dsl::*;
+        let price_0 = market_latest_state_event
+            .filter(market_id.eq(market_id_0.clone()))
+            .select(last_swap_avg_execution_price_q64)
+            .first::<BigDecimal>(conn)
+            .await?;
+        let price_1 = market_latest_state_event
+            .filter(market_id.eq(market_id_1.clone()))
+            .select(last_swap_avg_execution_price_q64)
+            .first::<BigDecimal>(conn)
+            .await?;
+        (price_0, price_1)
+    };
+    Ok(Some(MeleeData {
+        melee_id,
+        market_id_0,
+        market_id_1,
+        price_0,
+        price_1,
+    }))
+}
+
+/// Gets the latest processed version from the database.
+async fn get_version_from_db(connection_pool: ArcDbPool) -> anyhow::Result<u64> {
+    let conn = &mut connection_pool.get().await?;
+    let version = {
+        use schema::emojicoin_last_processed_transaction::dsl::*;
+        let v = emojicoin_last_processed_transaction
+            .select(version)
+            .get_results::<i64>(conn)
+            .await?;
+        v.as_slice().first().cloned()
+    };
+    if let Some(version) = version {
+        Ok(version.try_into().expect("Last version is negative"))
+    } else {
+        Ok::<u64, anyhow::Error>(0)
+    }
 }
 
 impl EmojicoinProcessor {
@@ -59,56 +124,19 @@ impl EmojicoinProcessor {
         per_table_chunk_sizes: AHashMap<String, usize>,
         notif_sender: UnboundedSender<EmojicoinDbEvent>,
     ) -> Self {
-        let task = async {
-            if ARENA_MODULE_ADDRESS.is_none() {
-                return Ok::<Option<MeleeData>, anyhow::Error>(None);
-            }
-            let conn = &mut connection_pool.get().await?;
-            let melee = {
-                use schema::arena_info::dsl::*;
-                let melee = arena_info
-                    .select((melee_id, emojicoin_0_market_id, emojicoin_1_market_id))
-                    .order(melee_id.desc())
-                    .limit(1)
-                    .get_results::<(BigDecimal, Option<BigDecimal>, Option<BigDecimal>)>(conn)
-                    .await?;
-                melee.as_slice().first().cloned()
-            };
-            if melee.is_none() {
-                return Ok::<Option<MeleeData>, anyhow::Error>(None);
-            }
-            let (melee_id, market_id_0, market_id_1) = melee.unwrap();
-            let (market_id_0, market_id_1) = (market_id_0.unwrap(), market_id_1.unwrap());
-            let (price_0, price_1) = {
-                use schema::market_latest_state_event::dsl::*;
-                let price_0 = market_latest_state_event
-                    .filter(market_id.eq(market_id_0.clone()))
-                    .select(last_swap_avg_execution_price_q64)
-                    .first::<BigDecimal>(conn)
-                    .await?;
-                let price_1 = market_latest_state_event
-                    .filter(market_id.eq(market_id_1.clone()))
-                    .select(last_swap_avg_execution_price_q64)
-                    .first::<BigDecimal>(conn)
-                    .await?;
-                (price_0, price_1)
-            };
-            Ok(Some(MeleeData {
-                melee_id,
-                market_id_0,
-                market_id_1,
-                price_0,
-                price_1,
-            }))
-        };
+        let melee_data_task = async { get_melee_data_from_db(connection_pool.clone()).await };
 
-        let melee_data = futures::executor::block_on(task).unwrap();
+        let version_task = async { get_version_from_db(connection_pool.clone()).await };
+
+        let melee_data = futures::executor::block_on(melee_data_task).unwrap();
+        let version = futures::executor::block_on(version_task).unwrap();
 
         Self {
             connection_pool,
             per_table_chunk_sizes,
             notif_sender,
             melee_data: Arc::new(RwLock::new(melee_data)),
+            version: Arc::new(RwLock::new(version)),
         }
     }
 
@@ -151,16 +179,17 @@ struct InsertEvents {
     arena_info: Vec<ArenaInfoModel>,
     arena_leaderboard_history: Vec<ArenaLeaderboardHistoryPartialModel>,
     arena_info_update: Vec<ArenaInfoDiffUpdate>,
-    arena_candlesticks: Vec<ArenaCandlestickDiffModel>,
+    arena_candlesticks: Vec<ArenaCandlestickModel>,
 }
 
 async fn insert_to_db(
-    conn: ArcDbPool,
+    pool: ArcDbPool,
     name: &'static str,
     start_version: u64,
     end_version: u64,
     insert_events: InsertEvents,
     per_table_chunk_sizes: &AHashMap<String, usize>,
+    max_transaction_version: u64,
 ) -> Result<(), diesel::result::Error> {
     tracing::trace!(
         name = name,
@@ -190,208 +219,225 @@ async fn insert_to_db(
         arena_candlesticks,
     } = insert_events;
 
-    let futures = vec![
-        execute_in_chunks(
-            conn.clone(),
-            insert_market_registration_events_query,
-            &market_registration_events,
-            get_config_table_chunk_size::<MarketRegistrationEventModel>(
-                "market_registration_events",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            delete_unregistered_markets_query,
-            &market_registration_events,
-            get_config_table_chunk_size::<MarketRegistrationEventModel>(
-                "unregistered_markets",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        // Note that this is currently not chunked and could result in a query that deletes several
-        // hundred rows at once.
-        MarketOneMinutePeriodsInLastDayModel::insert_and_delete_periods(
-            &market_1m_periods,
-            conn.clone(),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_swap_events_query,
-            &swap_events,
-            get_config_table_chunk_size::<SwapEventModel>("swap_events", per_table_chunk_sizes),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_chat_events_query,
-            &chat_events,
-            get_config_table_chunk_size::<ChatEventModel>("chat_events", per_table_chunk_sizes),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_liquidity_events_query,
-            &liquidity_events,
-            get_config_table_chunk_size::<LiquidityEventModel>(
-                "liquidity_events",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_periodic_state_events_query,
-            &periodic_state_events,
-            get_config_table_chunk_size::<PeriodicStateEventModel>(
-                "periodic_state_events",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_global_events,
-            &global_state_events,
-            get_config_table_chunk_size::<GlobalStateEventModel>(
-                "global_state_events",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_user_liquidity_pools_query,
-            &user_pools,
-            get_config_table_chunk_size::<UserLiquidityPoolsModel>(
-                "user_liquidity_pools",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_market_latest_state_event_query,
-            &market_latest_state_events,
-            get_config_table_chunk_size::<MarketLatestStateEventModel>(
-                "market_latest_state_events",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_arena_position_query,
-            &arena_position,
-            get_config_table_chunk_size::<ArenaPositionDiffModel>(
-                "arena_position",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_arena_info_query,
-            &arena_info,
-            get_config_table_chunk_size::<ArenaPositionDiffModel>(
-                "arena_info",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            update_arena_info_query,
-            &arena_info_update,
-            get_config_table_chunk_size::<ArenaPositionDiffModel>(
-                "arena_info",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_arena_enter_events_query,
-            &arena_enter_events,
-            get_config_table_chunk_size::<ArenaEnterEventModel>(
-                "arena_enter_events",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_arena_exit_events_query,
-            &arena_exit_events,
-            get_config_table_chunk_size::<ArenaExitEventModel>(
-                "arena_exit_events",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_arena_swap_events_query,
-            &arena_swap_events,
-            get_config_table_chunk_size::<ArenaSwapEventModel>(
-                "arena_swap_events",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_arena_vault_balance_update_events_query,
-            &arena_vault_balance_update_events,
-            get_config_table_chunk_size::<ArenaVaultBalanceUpdateEventModel>(
-                "arena_vault_balance_update_events",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_arena_melee_events_query,
-            &arena_melee_events,
-            get_config_table_chunk_size::<ArenaMeleeEventModel>(
-                "arena_melee_events",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_in_chunks(
-            conn.clone(),
-            insert_arena_candlesticks_query,
-            &arena_candlesticks,
-            get_config_table_chunk_size::<ArenaCandlestickDiffModel>(
-                "arena_candlestick",
-                per_table_chunk_sizes,
-            ),
-        )
-        .boxed(),
-        execute_single(
-            conn.clone(),
-            update_arena_leaderboard_history_query,
-            &arena_exit_events,
-        )
-        .boxed(),
-    ];
+    let mut conn = pool.get().await.unwrap();
 
-    try_join_all(futures).await?;
+    conn.transaction(|conn| {
+        async move {
+            execute_in_transaction(
+                conn,
+                insert_market_registration_events_query,
+                &market_registration_events,
+                get_config_table_chunk_size::<MarketRegistrationEventModel>(
+                    "market_registration_events",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                delete_unregistered_markets_query,
+                &market_registration_events,
+                get_config_table_chunk_size::<MarketRegistrationEventModel>(
+                    "unregistered_markets",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            // Note that this is currently not chunked and could result in a query that deletes several
+            // hundred rows at once.
+            MarketOneMinutePeriodsInLastDayModel::insert_and_delete_periods(
+                market_1m_periods,
+                conn,
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_swap_events_query,
+                &swap_events,
+                get_config_table_chunk_size::<SwapEventModel>("swap_events", per_table_chunk_sizes),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_chat_events_query,
+                &chat_events,
+                get_config_table_chunk_size::<ChatEventModel>("chat_events", per_table_chunk_sizes),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_liquidity_events_query,
+                &liquidity_events,
+                get_config_table_chunk_size::<LiquidityEventModel>(
+                    "liquidity_events",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_periodic_state_events_query,
+                &periodic_state_events,
+                get_config_table_chunk_size::<PeriodicStateEventModel>(
+                    "periodic_state_events",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_global_events,
+                &global_state_events,
+                get_config_table_chunk_size::<GlobalStateEventModel>(
+                    "global_state_events",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_user_liquidity_pools_query,
+                &user_pools,
+                get_config_table_chunk_size::<UserLiquidityPoolsModel>(
+                    "user_liquidity_pools",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_market_latest_state_event_query,
+                &market_latest_state_events,
+                get_config_table_chunk_size::<MarketLatestStateEventModel>(
+                    "market_latest_state_events",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_arena_position_query,
+                &arena_position,
+                get_config_table_chunk_size::<ArenaPositionDiffModel>(
+                    "arena_position",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_arena_info_query,
+                &arena_info,
+                get_config_table_chunk_size::<ArenaPositionDiffModel>(
+                    "arena_info",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                update_arena_info_query,
+                &arena_info_update,
+                get_config_table_chunk_size::<ArenaPositionDiffModel>(
+                    "arena_info",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_arena_enter_events_query,
+                &arena_enter_events,
+                get_config_table_chunk_size::<ArenaEnterEventModel>(
+                    "arena_enter_events",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_arena_exit_events_query,
+                &arena_exit_events,
+                get_config_table_chunk_size::<ArenaExitEventModel>(
+                    "arena_exit_events",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_arena_swap_events_query,
+                &arena_swap_events,
+                get_config_table_chunk_size::<ArenaSwapEventModel>(
+                    "arena_swap_events",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_arena_vault_balance_update_events_query,
+                &arena_vault_balance_update_events,
+                get_config_table_chunk_size::<ArenaVaultBalanceUpdateEventModel>(
+                    "arena_vault_balance_update_events",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_arena_melee_events_query,
+                &arena_melee_events,
+                get_config_table_chunk_size::<ArenaMeleeEventModel>(
+                    "arena_melee_events",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_in_transaction(
+                conn,
+                insert_arena_candlesticks_query,
+                &arena_candlesticks,
+                get_config_table_chunk_size::<ArenaCandlestickModel>(
+                    "arena_candlesticks",
+                    per_table_chunk_sizes,
+                ),
+            )
+            .await?;
+            execute_single_transaction(
+                conn,
+                update_arena_leaderboard_history_query,
+                &arena_exit_events,
+            )
+            .await?;
 
-    if ARENA_MODULE_ADDRESS.is_some() {
-        // Run this after everything else to make sure necessary events for the generation of the
-        // leaderboard history are already inserted.
-        execute_single(
-            conn.clone(),
-            insert_arena_leaderboard_history_query,
-            &arena_leaderboard_history,
-        )
-        .await?;
-    }
+            if ARENA_MODULE_ADDRESS.is_some() {
+                // Run this after everything else to make sure necessary events for the generation of the
+                // leaderboard history are already inserted.
+                execute_single_transaction(
+                    conn,
+                    insert_arena_leaderboard_history_query,
+                    &arena_leaderboard_history,
+                )
+                .await?;
+            }
+
+            {
+                use schema::emojicoin_last_processed_transaction::dsl::*;
+                diesel::insert_into(emojicoin_last_processed_transaction)
+                    .values((id.eq(1), version.eq(max_transaction_version as i64)))
+                    .on_conflict(id)
+                    .do_update()
+                    .set(version.eq(excluded(version)))
+                    .execute(conn)
+                    .await?;
+            }
+
+            Ok::<(), diesel::result::Error>(())
+        }
+        .scope_boxed()
+    })
+    .await?;
 
     Ok(())
 }
@@ -501,7 +547,7 @@ impl EmojicoinProcessor {
             u64,
             (TxnInfo, MarketResource, Trigger, InstantaneousStats),
         >,
-        arena_candlestick_builders: &mut Vec<ArenaCandlestickDiffModelBuilder>,
+        arena_candlesticks_builders: &mut Vec<ArenaCandlestickDiffModelBuilder>,
         states: &mut AHashMap<BigDecimal, StateEvent>,
         insert_events: &mut InsertEvents,
     ) -> anyhow::Result<()> {
@@ -588,7 +634,7 @@ impl EmojicoinProcessor {
                                                 melee_data.price_0.clone(),
                                                 melee_data.price_1.clone(),
                                             );
-                                        arena_candlestick_builders.extend(candlestick);
+                                        arena_candlesticks_builders.extend(candlestick);
                                     }
                                 }
                             },
@@ -636,9 +682,12 @@ impl EmojicoinProcessor {
                                 // Add to leaderboard history
                                 // This would be None only on the first MeleeEvent
                                 if let Some(melee_data) = melee_data.as_ref() {
-                                    insert_events
-                                        .arena_leaderboard_history
-                                        .push(ArenaLeaderboardHistoryPartialModel::new(melee_data));
+                                    insert_events.arena_leaderboard_history.push(
+                                        ArenaLeaderboardHistoryPartialModel::new(
+                                            melee_data,
+                                            txn_info.version,
+                                        ),
+                                    );
                                 }
 
                                 // Add to arena info
@@ -895,6 +944,8 @@ impl ProcessorTrait for EmojicoinProcessor {
         let processing_start = std::time::Instant::now();
         let last_transaction_timestamp = transactions.last().unwrap().timestamp.clone();
 
+        let prev_last_success_version = *self.version.read().await;
+
         let mut insert_events = InsertEvents {
             market_registration_events: vec![],
             swap_events: vec![],
@@ -925,12 +976,18 @@ impl ProcessorTrait for EmojicoinProcessor {
         > = AHashMap::new();
         let mut user_pools_db: AHashMap<(String, u64), UserLiquidityPoolsModel> = AHashMap::new();
         let mut period_data = vec![];
-        let mut arena_candlestick_builders = vec![];
+        let mut arena_candlesticks_builders = vec![];
 
         let mut market_registrations = vec![];
         let mut states: AHashMap<BigDecimal, StateEvent> = AHashMap::new();
 
+        let mut max_transaction_version = 0;
+
         for txn in &transactions {
+            max_transaction_version = std::cmp::max(max_transaction_version, txn.version);
+            if txn.version <= prev_last_success_version {
+                continue;
+            }
             let res = self
                 .process_transaction(
                     txn,
@@ -938,7 +995,7 @@ impl ProcessorTrait for EmojicoinProcessor {
                     &mut market_registrations,
                     &mut period_data,
                     &mut latest_market_resources,
-                    &mut arena_candlestick_builders,
+                    &mut arena_candlesticks_builders,
                     &mut states,
                     &mut insert_events,
                 )
@@ -974,7 +1031,7 @@ impl ProcessorTrait for EmojicoinProcessor {
             ArenaInfoDiffUpdate::merge(insert_events.arena_info_update);
 
         insert_events.arena_candlesticks =
-            ArenaCandlestickDiffModelBuilder::merge(arena_candlestick_builders)
+            ArenaCandlestickDiffModelBuilder::merge(arena_candlesticks_builders)
                 .into_iter()
                 .map(|a| a.into())
                 .collect();
@@ -1001,6 +1058,7 @@ impl ProcessorTrait for EmojicoinProcessor {
             EmojicoinDbEvent::from_arena_vault_balance_update(
                 &insert_events.arena_vault_balance_update_events,
             ),
+            EmojicoinDbEvent::from_arena_candlesticks(&insert_events.arena_candlesticks),
         ]
         .into_iter()
         .flatten()
@@ -1015,12 +1073,14 @@ impl ProcessorTrait for EmojicoinProcessor {
             end_version,
             insert_events,
             &self.per_table_chunk_sizes,
+            max_transaction_version,
         )
         .await;
 
         let db_insertion_duration_in_secs = db_insertion_start.elapsed().as_secs_f64();
         match tx_result {
             Ok(_) => {
+                *self.version.write().await = end_version;
                 let res = ProcessingResult::DefaultProcessingResult(DefaultProcessingResult {
                     start_version,
                     end_version,

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -581,9 +581,9 @@ impl EmojicoinProcessor {
                                         };
                                         let candlestick =
                                             ArenaCandlestickDiffModelBuilder::from_state_event(
+                                                &txn_info,
                                                 melee_data.melee_id.clone(),
                                                 state.clone(),
-                                                txn_info.timestamp,
                                                 (txn_info.version, event_index as i64),
                                                 melee_data.price_0.clone(),
                                                 melee_data.price_1.clone(),
@@ -648,7 +648,8 @@ impl EmojicoinProcessor {
                                     emojicoin_0_symbols: market_0.symbol_emojis,
                                     emojicoin_1_symbols: market_1.symbol_emojis,
                                 };
-                                let arena_info = ArenaInfoModel::new(model, arena_info_data);
+                                let arena_info =
+                                    ArenaInfoModel::new(&txn_info, model, arena_info_data);
                                 insert_events.arena_info.push(arena_info);
 
                                 // Update state
@@ -661,9 +662,9 @@ impl EmojicoinProcessor {
                                 });
                             },
                             ArenaEvent::Enter(enter) => {
-                                insert_events
-                                    .arena_position
-                                    .push(ArenaPositionDiffModel::from(enter.clone()));
+                                insert_events.arena_position.push(
+                                    ArenaPositionDiffModel::from_enter(&txn_info, enter.clone()),
+                                );
                                 let model = ArenaEnterEventModel::new(txn_info.clone(), enter);
                                 insert_events
                                     .arena_info_update
@@ -671,9 +672,9 @@ impl EmojicoinProcessor {
                                 insert_events.arena_enter_events.push(model)
                             },
                             ArenaEvent::Exit(exit) => {
-                                insert_events
-                                    .arena_position
-                                    .push(ArenaPositionDiffModel::from(exit.clone()));
+                                insert_events.arena_position.push(
+                                    ArenaPositionDiffModel::from_exit(&txn_info, exit.clone()),
+                                );
                                 let model = ArenaExitEventModel::new(
                                     txn_info.clone(),
                                     exit,
@@ -702,6 +703,7 @@ impl EmojicoinProcessor {
                                     };
                                 insert_events.arena_position.push(
                                     ArenaPositionDiffModel::from_swap(
+                                        &txn_info,
                                         swap.clone(),
                                         &emojicoin_0,
                                         &emojicoin_1,

--- a/rust/processor/src/utils/database.rs
+++ b/rust/processor/src/utils/database.rs
@@ -126,6 +126,32 @@ pub async fn new_db_pool(
     Ok(Arc::new(pool))
 }
 
+pub async fn execute_in_transaction<U, T>(
+    conn: &mut PooledConnection<'_, AsyncPgConnection>,
+    build_query: fn(Vec<T>) -> (U, Option<&'static str>),
+    items_to_insert: &[T],
+    chunk_size: usize,
+) -> Result<(), diesel::result::Error>
+where
+    U: QueryFragment<Backend> + diesel::query_builder::QueryId + Send + 'static,
+    T: serde::Serialize + for<'de> serde::Deserialize<'de> + Clone + Send + 'static,
+{
+    for chunk in items_to_insert.chunks(chunk_size) {
+        let items = chunk.to_vec();
+        let (query, additional_where_clause) = build_query(items.clone());
+        execute_or_retry_cleaned_transaction(
+            conn,
+            build_query,
+            items,
+            query,
+            additional_where_clause,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
 pub async fn execute_in_chunks<U, T>(
     conn: ArcDbPool,
     build_query: fn(Vec<T>) -> (U, Option<&'static str>),
@@ -183,6 +209,22 @@ where
     Ok(())
 }
 
+pub async fn execute_single_transaction<U, T>(
+    conn: &mut PooledConnection<'_, AsyncPgConnection>,
+    build_query: fn(T) -> U,
+    items_to_insert: &[T],
+) -> Result<(), diesel::result::Error>
+where
+    U: QueryFragment<Backend> + diesel::query_builder::QueryId + Send + 'static,
+    T: serde::Serialize + for<'de> serde::Deserialize<'de> + Clone + Send + 'static,
+{
+    for item in items_to_insert {
+        let query = build_query(item.clone());
+        execute_with_better_error_transaction(conn, query, None).await?;
+    }
+    Ok(())
+}
+
 pub async fn execute_with_better_error<U>(
     pool: ArcDbPool,
     query: U,
@@ -210,6 +252,33 @@ where
             Box::new(e.to_string()),
         )
     })?;
+    let res = final_query.execute(conn).await;
+    if let Err(ref e) = res {
+        tracing::warn!("Error running query: {:?}\n{:?}", e, debug_string);
+    }
+    res
+}
+
+pub async fn execute_with_better_error_transaction<U>(
+    conn: &mut PooledConnection<'_, AsyncPgConnection>,
+    query: U,
+    mut additional_where_clause: Option<&'static str>,
+) -> QueryResult<usize>
+where
+    U: QueryFragment<Backend> + diesel::query_builder::QueryId + Send,
+{
+    let original_query = diesel::debug_query::<Backend, _>(&query).to_string();
+    // This is needed because if we don't insert any row, then diesel makes a call like this
+    // SELECT 1 FROM TABLE WHERE 1=0
+    if original_query.to_lowercase().contains("where") {
+        additional_where_clause = None;
+    }
+    let final_query = UpsertFilterLatestTransactionQuery {
+        query,
+        where_clause: additional_where_clause,
+    };
+    let debug_string = diesel::debug_query::<Backend, _>(&final_query).to_string();
+    tracing::debug!("Executing query: {:?}", debug_string);
     let res = final_query.execute(conn).await;
     if let Err(ref e) = res {
         tracing::warn!("Error running query: {:?}\n{:?}", e, debug_string);
@@ -276,6 +345,39 @@ where
             let (cleaned_query, additional_where_clause) = build_query(cleaned_items);
             match execute_with_better_error(conn.clone(), cleaned_query, additional_where_clause)
                 .await
+            {
+                Ok(_) => {},
+                Err(e) => {
+                    return Err(e);
+                },
+            }
+        },
+    }
+    Ok(())
+}
+
+pub async fn execute_or_retry_cleaned_transaction<U, T>(
+    conn: &mut PooledConnection<'_, AsyncPgConnection>,
+    build_query: fn(Vec<T>) -> (U, Option<&'static str>),
+    items: Vec<T>,
+    query: U,
+    additional_where_clause: Option<&'static str>,
+) -> Result<(), diesel::result::Error>
+where
+    U: QueryFragment<Backend> + diesel::query_builder::QueryId + Send,
+    T: serde::Serialize + for<'de> serde::Deserialize<'de> + Clone,
+{
+    match execute_with_better_error_transaction(conn, query, additional_where_clause).await {
+        Ok(_) => {},
+        Err(_) => {
+            let cleaned_items = clean_data_for_db(items, true);
+            let (cleaned_query, additional_where_clause) = build_query(cleaned_items);
+            match execute_with_better_error_transaction(
+                conn,
+                cleaned_query,
+                additional_where_clause,
+            )
+            .await
             {
                 Ok(_) => {},
                 Err(e) => {


### PR DESCRIPTION
# Description

Since lots of the tables for arena represent the latest state for some data- it's important to include the latest transaction version processed in the column to ensure we don't ever overwrite it.

- [x] Add `last_transaction_version` to any query that doesn't `ON CONFLICT DO NOTHING` (aka on conflict it still writes/updates)
- [x] Consider that if any of these added clauses don't make sense or will break the processing logic- it means the processing logic is too fragile and should be more properly grouped