### PR TITLE
chore(ECO-2946): Add `last_transaction_version` to all remaining tables; emit candlesticks; truncate candlestick prices

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/constants.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/constants.rs
@@ -1,4 +1,5 @@
 use lazy_static::lazy_static;
+use std::num::NonZeroU64;
 
 // Only for use below to construct the lazy static strings.
 const SWAP: &str = "::emojicoin_dot_fun::Swap";
@@ -14,6 +15,7 @@ const ARENA_ENTER: &str = "::emojicoin_arena::Enter";
 const ARENA_EXIT: &str = "::emojicoin_arena::Exit";
 const ARENA_SWAP: &str = "::emojicoin_arena::Swap";
 const ARENA_VAULT_BALANCE_UPDATE: &str = "::emojicoin_arena::VaultBalanceUpdate";
+pub const CANDLESTICK_DECIMALS: NonZeroU64 = NonZeroU64::new(16).unwrap();
 
 lazy_static! {
     pub static ref MODULE_ADDRESS: String = std::env::var("EMOJICOIN_MODULE_ADDRESS")

--- a/rust/processor/src/db/common/models/emojicoin_models/enums.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/enums.rs
@@ -189,6 +189,8 @@ pub enum EmojicoinDbEvent {
     ArenaExit(ArenaExitEventModel),
     ArenaSwap(ArenaSwapEventModel),
     ArenaVaultBalanceUpdate(ArenaVaultBalanceUpdateEventModel),
+    // Not an actual event in the contract- but is sent to the broker.
+    ArenaCandlestick(ArenaCandlestickModel),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -221,6 +223,7 @@ pub enum EmojicoinDbEventType {
     ArenaExit,
     ArenaSwap,
     ArenaVaultBalanceUpdate,
+    ArenaCandlestickDiffModel,
 }
 
 impl From<&EmojicoinEvent> for EmojicoinEventType {
@@ -261,6 +264,7 @@ impl From<&EmojicoinDbEvent> for EmojicoinDbEventType {
             EmojicoinDbEvent::ArenaExit(_) => Self::ArenaExit,
             EmojicoinDbEvent::ArenaSwap(_) => Self::ArenaSwap,
             EmojicoinDbEvent::ArenaVaultBalanceUpdate(_) => Self::ArenaVaultBalanceUpdate,
+            EmojicoinDbEvent::ArenaCandlestick(_) => Self::ArenaCandlestickDiffModel,
         }
     }
 }
@@ -351,6 +355,14 @@ impl EmojicoinDbEvent {
             .iter()
             .cloned()
             .map(Self::ArenaVaultBalanceUpdate)
+            .collect()
+    }
+
+    pub fn from_arena_candlesticks(candlesticks: &[ArenaCandlestickModel]) -> Vec<Self> {
+        candlesticks
+            .iter()
+            .cloned()
+            .map(Self::ArenaCandlestick)
             .collect()
     }
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/enums.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/enums.rs
@@ -223,7 +223,8 @@ pub enum EmojicoinDbEventType {
     ArenaExit,
     ArenaSwap,
     ArenaVaultBalanceUpdate,
-    ArenaCandlestickDiffModel,
+    // Not an actual event in the contract- but is sent to the broker.
+    ArenaCandlestick,
 }
 
 impl From<&EmojicoinEvent> for EmojicoinEventType {
@@ -264,7 +265,7 @@ impl From<&EmojicoinDbEvent> for EmojicoinDbEventType {
             EmojicoinDbEvent::ArenaExit(_) => Self::ArenaExit,
             EmojicoinDbEvent::ArenaSwap(_) => Self::ArenaSwap,
             EmojicoinDbEvent::ArenaVaultBalanceUpdate(_) => Self::ArenaVaultBalanceUpdate,
-            EmojicoinDbEvent::ArenaCandlestick(_) => Self::ArenaCandlestickDiffModel,
+            EmojicoinDbEvent::ArenaCandlestick(_) => Self::ArenaCandlestick,
         }
     }
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlestick.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlestick.rs
@@ -109,7 +109,7 @@ impl ArenaCandlestickDiffModelBuilder {
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(melee_id, period, start_time))]
 #[diesel(table_name = arena_candlestick)]
-pub struct ArenaCandlestickDiffModel {
+pub struct ArenaCandlestickModel {
     pub melee_id: BigDecimal,
     pub last_transaction_version: i64,
 
@@ -124,7 +124,7 @@ pub struct ArenaCandlestickDiffModel {
     pub n_swaps: BigDecimal,
 }
 
-impl From<ArenaCandlestickDiffModelBuilder> for ArenaCandlestickDiffModel {
+impl From<ArenaCandlestickDiffModelBuilder> for ArenaCandlestickModel {
     fn from(value: ArenaCandlestickDiffModelBuilder) -> Self {
         Self {
             melee_id: value.melee_id,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlestick.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlestick.rs
@@ -1,11 +1,12 @@
 use crate::{
     db::common::models::emojicoin_models::{
+        constants::CANDLESTICK_DECIMALS,
         enums::Period,
         json_types::{StateEvent, TxnInfo},
     },
     schema::arena_candlestick,
 };
-use bigdecimal::BigDecimal;
+use bigdecimal::{BigDecimal, RoundingMode};
 use chrono::{DurationRound, NaiveDateTime};
 use field_count::FieldCount;
 use num::FromPrimitive;
@@ -124,6 +125,12 @@ pub struct ArenaCandlestickModel {
     pub n_swaps: BigDecimal,
 }
 
+impl ArenaCandlestickModel {
+    fn truncate(value: BigDecimal) -> BigDecimal {
+        value.with_precision_round(CANDLESTICK_DECIMALS, RoundingMode::HalfEven)
+    }
+}
+
 impl From<ArenaCandlestickDiffModelBuilder> for ArenaCandlestickModel {
     fn from(value: ArenaCandlestickDiffModelBuilder) -> Self {
         Self {
@@ -133,10 +140,10 @@ impl From<ArenaCandlestickDiffModelBuilder> for ArenaCandlestickModel {
             period: value.period,
             start_time: value.start_time,
 
-            open_price: value.open_price,
-            high_price: value.high_price,
-            low_price: value.low_price,
-            close_price: value.close_price,
+            open_price: Self::truncate(value.open_price),
+            high_price: Self::truncate(value.high_price),
+            low_price: Self::truncate(value.low_price),
+            close_price: Self::truncate(value.close_price),
 
             volume: value.volume,
             n_swaps: value.n_swaps,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlesticks.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlesticks.rs
@@ -4,7 +4,7 @@ use crate::{
         enums::Period,
         json_types::{StateEvent, TxnInfo},
     },
-    schema::arena_candlestick,
+    schema::arena_candlesticks,
 };
 use bigdecimal::{BigDecimal, RoundingMode};
 use chrono::{DurationRound, NaiveDateTime};
@@ -109,7 +109,7 @@ impl ArenaCandlestickDiffModelBuilder {
 }
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(melee_id, period, start_time))]
-#[diesel(table_name = arena_candlestick)]
+#[diesel(table_name = arena_candlesticks)]
 pub struct ArenaCandlestickModel {
     pub melee_id: BigDecimal,
     pub last_transaction_version: i64,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_leaderboard_history.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_leaderboard_history.rs
@@ -5,16 +5,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ArenaLeaderboardHistoryPartialModel {
     pub melee_id: BigDecimal,
+    pub last_transaction_version: i64,
 
     pub emojicoin_0_price: BigDecimal,
     pub emojicoin_1_price: BigDecimal,
 }
 
 impl ArenaLeaderboardHistoryPartialModel {
-    pub fn new(melee_data: &MeleeData) -> ArenaLeaderboardHistoryPartialModel {
+    pub fn new(
+        melee_data: &MeleeData,
+        last_transaction_version: i64,
+    ) -> ArenaLeaderboardHistoryPartialModel {
         ArenaLeaderboardHistoryPartialModel {
             melee_id: melee_data.melee_id.clone(),
-
+            last_transaction_version,
             emojicoin_0_price: melee_data.price_0.clone(),
             emojicoin_1_price: melee_data.price_1.clone(),
         }

--- a/rust/processor/src/db/common/models/emojicoin_models/models/market_1m_periods_in_last_day.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/market_1m_periods_in_last_day.rs
@@ -1,8 +1,5 @@
 use super::market_24h_rolling_volume::RecentOneMinutePeriodicStateEvent;
-use crate::{
-    schema::{self, market_1m_periods_in_last_day},
-    utils::database::ArcDbPool,
-};
+use crate::schema::{self, market_1m_periods_in_last_day};
 use bigdecimal::BigDecimal;
 use chrono::NaiveDateTime;
 use diesel::{

--- a/rust/processor/src/db/common/models/emojicoin_models/models/mod.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/mod.rs
@@ -1,4 +1,4 @@
-pub mod arena_candlestick;
+pub mod arena_candlesticks;
 pub mod arena_enter_event;
 pub mod arena_exit_event;
 pub mod arena_info;
@@ -20,7 +20,7 @@ pub mod user_liquidity_pools;
 
 pub mod prelude {
     pub use super::{
-        arena_candlestick::*, arena_enter_event::*, arena_exit_event::*, arena_info::*,
+        arena_candlesticks::*, arena_enter_event::*, arena_exit_event::*, arena_info::*,
         arena_leaderboard_history::*, arena_melee_event::*, arena_position::*, arena_swap_event::*,
         arena_vault_balance_update_event::*, chat_event::*, global_state_event::*,
         liquidity_event::*, market_1m_periods_in_last_day::*, market_24h_rolling_volume::*,

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
@@ -213,6 +213,7 @@ pub fn insert_arena_position_query(
             .do_update()
             .set((
                 open.eq(excluded(open)),
+                last_transaction_version.eq(excluded(last_transaction_version)),
                 emojicoin_0_balance.eq(emojicoin_0_balance + excluded(emojicoin_0_balance)),
                 emojicoin_1_balance.eq(emojicoin_1_balance + excluded(emojicoin_1_balance)),
                 deposits.eq(deposits + excluded(deposits)),
@@ -239,6 +240,7 @@ pub fn insert_arena_info_query(
             .on_conflict(melee_id)
             .do_update()
             .set((
+                last_transaction_version.eq(excluded(last_transaction_version)),
                 rewards_remaining.eq(rewards_remaining + excluded(rewards_remaining)),
                 emojicoin_0_market_address.eq(excluded(emojicoin_0_market_address)),
                 emojicoin_1_market_address.eq(excluded(emojicoin_1_market_address)),
@@ -298,10 +300,10 @@ pub fn insert_arena_leaderboard_history_query(
 
     // See header comment of leaderboard.sql for more information on query parameters.
 
-    // $1 is the melee_id
+    // $1 is the melee_id.
     query = query.replace("$1", &arena_leaderboard_history_model.melee_id.to_string());
 
-    // $2 is the curve price of emojicoin_0
+    // $2 is the curve price of emojicoin_0.
     query = query.replace(
         "$2",
         &arena_leaderboard_history_model
@@ -309,11 +311,19 @@ pub fn insert_arena_leaderboard_history_query(
             .to_string(),
     );
 
-    // $3 is the curve price of emojicoin_1
+    // $3 is the curve price of emojicoin_1.
     query = query.replace(
         "$3",
         &arena_leaderboard_history_model
             .emojicoin_1_price
+            .to_string(),
+    );
+
+    // $4 is the transaction version of this snapshot; i.e., when this melee ended.
+    query = query.replace(
+        "$4",
+        &arena_leaderboard_history_model
+            .last_transaction_version
             .to_string(),
     );
 
@@ -329,6 +339,7 @@ pub fn update_arena_leaderboard_history_query(
         .filter(user.eq(exit.user))
         .set((
             exited.eq(true),
+            last_transaction_version.eq(exit.transaction_version),
             last_exit_0.eq(exit.emojicoin_1_proceeds.is_zero()),
         ))
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
@@ -394,7 +394,7 @@ pub fn insert_arena_vault_balance_update_events_query(
 }
 
 pub fn insert_arena_candlesticks_query(
-    items_to_insert: Vec<ArenaCandlestickDiffModel>,
+    items_to_insert: Vec<ArenaCandlestickModel>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
@@ -399,9 +399,9 @@ pub fn insert_arena_candlesticks_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::arena_candlestick::dsl::*;
+    use schema::arena_candlesticks::dsl::*;
     (
-        diesel::insert_into(schema::arena_candlestick::table)
+        diesel::insert_into(schema::arena_candlesticks::table)
             .values(items_to_insert)
             .on_conflict((melee_id, period, start_time))
             .do_update()

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/leaderboard.sql
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/leaderboard.sql
@@ -11,6 +11,7 @@
 -- $1: the melee_id for which to calculate the leaderboard
 -- $2: the curve price of emojicoin_0 at the end of the melee
 -- $3: the curve price of emojicoin_1 at the end of the melee
+-- $4: the transaction version of the snapshot; i.e., when this melee ended
 
 INSERT INTO arena_leaderboard_history (
     "user",
@@ -83,6 +84,7 @@ last_balances AS (
 SELECT
     position."user",
     $1 AS melee_id,
+    $4 AS last_transaction_version,
     -- Profits = Withdrawals in APT + current emojicoin balance converted to APT.
     COALESCE(withdrawals, 0) +
         ROUND(

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/leaderboard.sql
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/leaderboard.sql
@@ -15,6 +15,7 @@
 
 INSERT INTO arena_leaderboard_history (
     "user",
+    last_transaction_version,
     melee_id,
     profits,
     losses,
@@ -83,8 +84,8 @@ last_balances AS (
 )
 SELECT
     position."user",
-    $1 AS melee_id,
     $4 AS last_transaction_version,
+    $1 AS melee_id,
     -- Profits = Withdrawals in APT + current emojicoin balance converted to APT.
     COALESCE(withdrawals, 0) +
         ROUND(

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/down.sql
@@ -9,6 +9,6 @@ DROP TABLE arena_vault_balance_update_events ;
 DROP TABLE arena_position ;
 DROP TABLE arena_leaderboard_history ;
 DROP TABLE arena_info ;
-DROP TABLE arena_candlestick ;
+DROP TABLE arena_candlesticks ;
 
 DROP TABLE emojicoin_last_processed_transaction ;

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
@@ -122,6 +122,7 @@ CREATE TABLE arena_position (
 
 CREATE TABLE arena_leaderboard_history (
     "user" TEXT NOT NULL,
+    last_transaction_version BIGINT NOT NULL,
     melee_id NUMERIC NOT NULL,
     profits NUMERIC NOT NULL,
     losses NUMERIC NOT NULL,

--- a/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-08-171729_emojicoin_arena/up.sql
@@ -156,7 +156,7 @@ CREATE TABLE arena_info (
     max_match_amount NUMERIC
 );
 
-CREATE TABLE arena_candlestick (
+CREATE TABLE arena_candlesticks (
     melee_id NUMERIC NOT NULL,
     last_transaction_version BIGINT NOT NULL,
 

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -98,7 +98,7 @@ diesel::table! {
     use diesel::sql_types::*;
     use super::sql_types::PeriodType;
 
-    arena_candlestick (melee_id, period, start_time) {
+    arena_candlesticks (melee_id, period, start_time) {
         melee_id -> Numeric,
         last_transaction_version -> Int8,
         period -> PeriodType,
@@ -1847,7 +1847,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     ans_lookup_v2,
     ans_primary_name,
     ans_primary_name_v2,
-    arena_candlestick,
+    arena_candlesticks,
     arena_enter_events,
     arena_exit_events,
     arena_info,

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -185,6 +185,7 @@ diesel::table! {
 diesel::table! {
     arena_leaderboard_history (user, melee_id) {
         user -> Text,
+        last_transaction_version -> Int8,
         melee_id -> Numeric,
         profits -> Numeric,
         losses -> Numeric,

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -399,7 +399,7 @@ async fn insert_to_db(
                 insert_arena_candlesticks_query,
                 &arena_candlesticks,
                 get_config_table_chunk_size::<ArenaCandlestickModel>(
-                    "arena_candlestick",
+                    "arena_candlesticks",
                     per_table_chunk_sizes,
                 ),
             )
@@ -547,7 +547,7 @@ impl EmojicoinProcessor {
             u64,
             (TxnInfo, MarketResource, Trigger, InstantaneousStats),
         >,
-        arena_candlestick_builders: &mut Vec<ArenaCandlestickDiffModelBuilder>,
+        arena_candlesticks_builders: &mut Vec<ArenaCandlestickDiffModelBuilder>,
         states: &mut AHashMap<BigDecimal, StateEvent>,
         insert_events: &mut InsertEvents,
     ) -> anyhow::Result<()> {
@@ -634,7 +634,7 @@ impl EmojicoinProcessor {
                                                 melee_data.price_0.clone(),
                                                 melee_data.price_1.clone(),
                                             );
-                                        arena_candlestick_builders.extend(candlestick);
+                                        arena_candlesticks_builders.extend(candlestick);
                                     }
                                 }
                             },
@@ -976,7 +976,7 @@ impl ProcessorTrait for EmojicoinProcessor {
         > = AHashMap::new();
         let mut user_pools_db: AHashMap<(String, u64), UserLiquidityPoolsModel> = AHashMap::new();
         let mut period_data = vec![];
-        let mut arena_candlestick_builders = vec![];
+        let mut arena_candlesticks_builders = vec![];
 
         let mut market_registrations = vec![];
         let mut states: AHashMap<BigDecimal, StateEvent> = AHashMap::new();
@@ -995,7 +995,7 @@ impl ProcessorTrait for EmojicoinProcessor {
                     &mut market_registrations,
                     &mut period_data,
                     &mut latest_market_resources,
-                    &mut arena_candlestick_builders,
+                    &mut arena_candlesticks_builders,
                     &mut states,
                     &mut insert_events,
                 )
@@ -1031,7 +1031,7 @@ impl ProcessorTrait for EmojicoinProcessor {
             ArenaInfoDiffUpdate::merge(insert_events.arena_info_update);
 
         insert_events.arena_candlesticks =
-            ArenaCandlestickDiffModelBuilder::merge(arena_candlestick_builders)
+            ArenaCandlestickDiffModelBuilder::merge(arena_candlesticks_builders)
                 .into_iter()
                 .map(|a| a.into())
                 .collect();

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -944,7 +944,7 @@ impl ProcessorTrait for EmojicoinProcessor {
         let processing_start = std::time::Instant::now();
         let last_transaction_timestamp = transactions.last().unwrap().timestamp.clone();
 
-        let prev_last_success_version = self.version.read().await.clone();
+        let prev_last_success_version = *self.version.read().await;
 
         let mut insert_events = InsertEvents {
             market_registration_events: vec![],

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -682,9 +682,12 @@ impl EmojicoinProcessor {
                                 // Add to leaderboard history
                                 // This would be None only on the first MeleeEvent
                                 if let Some(melee_data) = melee_data.as_ref() {
-                                    insert_events
-                                        .arena_leaderboard_history
-                                        .push(ArenaLeaderboardHistoryPartialModel::new(melee_data));
+                                    insert_events.arena_leaderboard_history.push(
+                                        ArenaLeaderboardHistoryPartialModel::new(
+                                            melee_data,
+                                            txn_info.version,
+                                        ),
+                                    );
                                 }
 
                                 // Add to arena info

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -179,7 +179,7 @@ struct InsertEvents {
     arena_info: Vec<ArenaInfoModel>,
     arena_leaderboard_history: Vec<ArenaLeaderboardHistoryPartialModel>,
     arena_info_update: Vec<ArenaInfoDiffUpdate>,
-    arena_candlesticks: Vec<ArenaCandlestickDiffModel>,
+    arena_candlesticks: Vec<ArenaCandlestickModel>,
 }
 
 async fn insert_to_db(
@@ -398,7 +398,7 @@ async fn insert_to_db(
                 conn,
                 insert_arena_candlesticks_query,
                 &arena_candlesticks,
-                get_config_table_chunk_size::<ArenaCandlestickDiffModel>(
+                get_config_table_chunk_size::<ArenaCandlestickModel>(
                     "arena_candlestick",
                     per_table_chunk_sizes,
                 ),
@@ -1058,6 +1058,7 @@ impl ProcessorTrait for EmojicoinProcessor {
             EmojicoinDbEvent::from_arena_vault_balance_update(
                 &insert_events.arena_vault_balance_update_events,
             ),
+            EmojicoinDbEvent::from_arena_candlesticks(&insert_events.arena_candlesticks),
         ]
         .into_iter()
         .flatten()


### PR DESCRIPTION
This ensures any updates or insertions have tables reflect the latest transaction version in use.

- [x] Add the `last_transaction_version` column back and in places it belongs
- [x] Emit candlesticks from the broker
- [x] Truncate the prices to 16 decimals so they're not nearly 80 decimal places

Also adds candlestick models to `EmojicoinDbEvent` types so the broker can use it

- [x] Add the types
- [x] Add them to `publish_events`