### PR TITLE
fix(ECO-2858): Chunk insertions of 1m periods to avoid crash

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/models/market_1m_periods_in_last_day.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/market_1m_periods_in_last_day.rs
@@ -1,5 +1,8 @@
 use super::market_24h_rolling_volume::RecentOneMinutePeriodicStateEvent;
-use crate::schema::{self, market_1m_periods_in_last_day};
+use crate::{
+    schema::{self, market_1m_periods_in_last_day},
+    utils::database::MAX_DIESEL_PARAM_SIZE,
+};
 use bigdecimal::BigDecimal;
 use chrono::NaiveDateTime;
 use diesel::{
@@ -48,14 +51,17 @@ impl MarketOneMinutePeriodsInLastDayModel {
 
         conn.transaction::<_, Error, _>(|conn| {
             async move {
-                let inserted = diesel_async::RunQueryDsl::execute(
-                    diesel::insert_into(schema::market_1m_periods_in_last_day::table)
-                        .values(&items)
-                        .on_conflict((market_id, nonce))
-                        .do_nothing(),
-                    conn,
-                )
-                .await?;
+                let mut inserted = 0;
+                for items in items.chunks(MAX_DIESEL_PARAM_SIZE) {
+                    inserted += diesel_async::RunQueryDsl::execute(
+                        diesel::insert_into(schema::market_1m_periods_in_last_day::table)
+                            .values(items)
+                            .on_conflict((market_id, nonce))
+                            .do_nothing(),
+                        conn,
+                    )
+                    .await?;
+                }
 
                 let deleted = diesel_async::RunQueryDsl::execute(
                     diesel::delete(schema::market_1m_periods_in_last_day::table)

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -243,8 +243,6 @@ async fn insert_to_db(
                 ),
             )
             .await?;
-            // Note that this is currently not chunked and could result in a query that deletes several
-            // hundred rows at once.
             MarketOneMinutePeriodsInLastDayModel::insert_and_delete_periods(
                 market_1m_periods,
                 conn,


### PR DESCRIPTION
This PR updates the 1m period insertion to avoid an error when too many are inserted at the same time.

Although highly unlikely, it is best to avoid this ever happening.