### PR TITLE
chore(ECO-2967): Branch off of production processor to add new user indexes

### DIFF
--- a/.github/workflows/check-n-lines-changed.yaml
+++ b/.github/workflows/check-n-lines-changed.yaml
@@ -1,0 +1,132 @@
+---
+env:
+  GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+  MAX_LINES_ADDED: 300
+  MAX_LINES_REMOVED: 500
+  OVERRIDE_N_APPROVALS: 2
+jobs:
+  check-n-lines-changed:
+    env:
+      # If run from a merge group, the action should not run. However there is
+      # no way to exit early in GitHub actions per
+      # https://github.com/actions/runner/issues/662, so using a conditional
+      # check for each step serves as a workaround.
+      IS_MERGE_GROUP: '${{ github.event_name == ''merge_group'' }}'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: 'actions/checkout@v4'
+      with:
+        fetch-depth: 0
+    - id: 'get-pr-number'
+      if: '${{ env.IS_MERGE_GROUP != ''true'' }}'
+      name: 'Get PR number'
+      # yamllint disable rule:indentation
+      run: |
+        PR_NUMBER=$(
+          if [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            echo "${{ github.event.pull_request.number }}"
+          else
+            echo "${{ github.event.pull_request.number }}"
+          fi
+        )
+        if [ -z "$PR_NUMBER" ]; then
+          echo "No PR number found. Exiting."
+          exit 1
+        fi
+        echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+    # yamllint enable rule:indentation
+    - id: 'get-base-branch'
+      if: '${{ env.IS_MERGE_GROUP != ''true'' }}'
+      name: 'Get PR base branch'
+      run: |
+        PR_NUMBER="${{ steps.get-pr-number.outputs.number }}"
+        BASE=$(gh pr view "$PR_NUMBER" --json baseRefName -q '.baseRefName')
+        echo "Base branch: $BASE"
+        echo "base_branch=$BASE" >> $GITHUB_OUTPUT
+    - id: 'get-insertions'
+      if: '${{ env.IS_MERGE_GROUP != ''true'' }}'
+      name: 'Get number of lines added'
+      # yamllint disable rule:indentation
+      run: |
+        BASE_BRANCH="${{ steps.get-base-branch.outputs.base_branch }}"
+        git fetch origin $BASE_BRANCH
+        INSERTIONS=$(
+          git diff --stat origin/$BASE_BRANCH | \
+          tail -n1 | grep -oP '\d+(?= insertion)' || echo "0"
+        )
+        echo "Number of lines added: $INSERTIONS"
+        echo "insertions=$INSERTIONS" >> $GITHUB_OUTPUT
+    # yamllint enable rule:indentation
+    - id: 'get-deletions'
+      if: '${{ env.IS_MERGE_GROUP != ''true'' }}'
+      name: 'Get number of lines removed'
+      # yamllint disable rule:indentation
+      run: |
+        BASE_BRANCH="${{ steps.get-base-branch.outputs.base_branch }}"
+        git fetch origin $BASE_BRANCH
+        DELETIONS=$(
+          git diff --stat origin/$BASE_BRANCH | \
+          tail -n1 | grep -oP '\d+(?= deletion)' || echo "0"
+        )
+        echo "Number of lines removed: $DELETIONS"
+        echo "deletions=$DELETIONS" >> $GITHUB_OUTPUT
+    # yamllint enable rule:indentation
+    - id: 'get-approvals'
+      if: '${{ env.IS_MERGE_GROUP != ''true'' }}'
+      name: 'Get number of active approving reviews'
+      # Sum up the number of approvals across all reviewers, only counting a
+      # review as approving if it is the last review by that reviewer.
+      # yamllint disable rule:indentation
+      run: |
+        APPROVALS=$(
+          gh pr view ${{ steps.get-pr-number.outputs.number }} \
+            --json reviews | \
+            jq '
+              .reviews
+              | group_by(.user.login)
+              | map(last)
+              | map(select(.state == "APPROVED"))
+              | length
+            '
+        )
+        echo "Number of approvals: $APPROVALS"
+        echo "approvals=$APPROVALS" >> $GITHUB_OUTPUT
+    # yamllint enable rule:indentation
+    - if: '${{ env.IS_MERGE_GROUP != ''true'' }}'
+      name: 'Check size versus approvals'
+      # yamllint disable rule:indentation
+      run: |
+        INSERTIONS="${{ steps.get-insertions.outputs.insertions }}"
+        DELETIONS="${{ steps.get-deletions.outputs.deletions }}"
+        echo "$INSERTIONS lines added (max ${{ env.MAX_LINES_ADDED }})"
+        echo "$DELETIONS lines removed (max ${{ env.MAX_LINES_REMOVED }})"
+        NEEDS_OVERRIDE="false"
+        if [ "$INSERTIONS" -gt "${{ env.MAX_LINES_ADDED }}" ]; then
+          NEEDS_OVERRIDE="true"
+        fi
+        if [ "$DELETIONS" -gt "${{ env.MAX_LINES_REMOVED }}" ]; then
+          NEEDS_OVERRIDE="true"
+        fi
+        if [ "$NEEDS_OVERRIDE" = "true" ]; then
+          APPROVALS="${{ steps.get-approvals.outputs.approvals }}"
+          OVERRIDE_N_APPROVALS="${{ env.OVERRIDE_N_APPROVALS }}"
+          if [ "$APPROVALS" -ge "$OVERRIDE_N_APPROVALS" ]; then
+            echo "✅ Changes exceeded limits but have required approvals"
+          else
+            echo "❌ Too many changes. Need $OVERRIDE_N_APPROVALS approvals"
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              echo "If the PR author hasn't updated this PR since enough"
+              echo "approvals were left, you must manually trigger a re-run"
+            fi
+            exit 1
+          fi
+        else
+          echo "✅ Changes within limits"
+        fi
+# yamllint enable rule:indentation
+name: 'Check number of lines changed'
+'on':
+  merge_group: null
+  pull_request: null
+  pull_request_review: null
+...

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,34 @@
+# cspell:word amannn
+---
+env:
+  GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+jobs:
+  conventional-commit:
+    env:
+      # If run from a merge group, the action should not run. However there is
+      # no way to exit early in GitHub actions per
+      # https://github.com/actions/runner/issues/662, so using a conditional
+      # check for each step serves as a workaround.
+      IS_MERGE_GROUP: '${{ github.event_name == ''merge_group'' }}'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      if: '${{ env.IS_MERGE_GROUP != ''true'' }}'
+      uses: 'amannn/action-semantic-pull-request@v5'
+      with:
+        requireScope: true
+        scopes: '^ECO-[0-9]+$'
+        subjectPattern: '^[A-Z].*$'
+        validateSingleCommit: true
+        validateSingleCommitMatchesPrTitle: true
+name: 'Verify conventional commit PR title'
+'on':
+  merge_group: null
+  pull_request:
+    types:
+    - 'edited'
+    - 'opened'
+    - 'reopened'
+    - 'synchronize'
+...

--- a/.github/workflows/push-processor.yaml
+++ b/.github/workflows/push-processor.yaml
@@ -1,59 +1,63 @@
 ---
+env:
+  BUILD_CONTEXT: 'rust'
+  BUILD_FILE: 'rust/Dockerfile'
+  DOCKER_REPO: 'econialabs/emojicoin-dot-fun-indexer-processor'
+  GIT_TAG_PREFIX: 'emojicoin-processor'
 jobs:
-  build-push:
-    runs-on: 'ubuntu-latest'
+  build:
+    outputs:
+      digest-amd64: >-
+        ${{ matrix.arch == 'amd64' && steps.build.outputs.digest || '' }}
+      digest-arm64: >-
+        ${{ matrix.arch == 'arm64' && steps.build.outputs.digest || '' }}
+    runs-on: '${{ matrix.runner }}'
     steps:
     - uses: 'actions/checkout@v4'
-    - id: 'metadata'
-      uses: 'docker/metadata-action@v5'
-      with:
-        images: 'econialabs/emojicoin-dot-fun-indexer-processor'
-        tags: |
-          type=match,pattern=emojicoin-processor-v(.*),group=1
-    - id: 'arm64-metadata'
-      uses: 'docker/metadata-action@v5'
-      with:
-        flavor: |
-          suffix=-arm64,onlatest=true
-        images: 'econialabs/emojicoin-dot-fun-indexer-processor'
-        tags: |
-          type=match,pattern=emojicoin-processor-v(.*),group=1
-    - uses: 'docker/setup-qemu-action@v3'
     - uses: 'docker/setup-buildx-action@v3'
     - uses: 'docker/login-action@v3'
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - name: 'Push AMD image to Docker Hub'
+    - id: 'build'
+      name: 'Build and push untagged ${{ matrix.arch }} digest to Docker Hub'
       uses: 'docker/build-push-action@v6'
       with:
         cache-from: 'type=gha'
         cache-to: 'type=gha,mode=max'
-        context: 'rust'
-        file: 'rust/Dockerfile'
-        platforms: 'linux/amd64'
-        push: 'true'
-        tags: '${{ steps.metadata.outputs.tags }}'
-    - name: 'Clear Docker cache to free up space for ARM build'
-      run: 'docker system prune -af'
-    - name: 'Push ARM image to Docker Hub'
-      uses: 'docker/build-push-action@v6'
+        context: '${{ env.BUILD_CONTEXT }}'
+        file: '${{ env.BUILD_FILE }}'
+        outputs: 'name=${{ env.DOCKER_REPO }},push-by-digest=true,type=image'
+        platforms: 'linux/${{ matrix.arch }}'
+        push: true
+    strategy:
+      matrix:
+        include:
+        - arch: 'amd64'
+          runner: 'ubuntu-latest'
+        - arch: 'arm64'
+          runner: 'ubuntu-24.04-arm'
+  create-manifest:
+    needs: 'build'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: 'docker/setup-buildx-action@v3'
+    - uses: 'docker/login-action@v3'
       with:
-        cache-from: 'type=gha'
-        cache-to: 'type=gha,mode=max'
-        context: 'rust'
-        file: 'rust/Dockerfile'
-        platforms: 'linux/arm64'
-        push: 'true'
-        tags: '${{ steps.arm64-metadata.outputs.tags }}'
-    - name: 'Append ARM images to AMD manifest'
+        password: '${{ secrets.DOCKERHUB_TOKEN }}'
+        username: '${{ secrets.DOCKERHUB_USERNAME }}'
+    - id: 'metadata'
+      uses: 'docker/metadata-action@v5'
+      with:
+        images: '${{ env.DOCKER_REPO }}'
+        tags: 'type=match,pattern=${{ env.GIT_TAG_PREFIX }}-v(.*),group=1'
+    - name: 'Create multi-architecture image manifest on Docker Hub'
       run: |
-        echo "${{ steps.metadata.outputs.tags }}" | while read -r tag; do
-        if [ ! -z "$tag" ]; then
-        docker buildx imagetools create --append -t "$tag" "${tag}-arm64"
-        fi
-        done
-    timeout-minutes: 360
+        TAG_ARGS=$(jq -cr '.tags | map("-t " + .) | join(" ")' \
+        <<< '${{ steps.metadata.outputs.json }}')
+        docker buildx imagetools create ${TAG_ARGS} \
+        ${{ env.DOCKER_REPO }}@${{ needs.build.outputs.digest-amd64 }} \
+        ${{ env.DOCKER_REPO }}@${{ needs.build.outputs.digest-arm64 }}
 name: 'Push multi-platform processor image to Docker Hub'
 'on':
   push:

--- a/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -237,6 +237,9 @@ pub struct SwapEvent {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ChatEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub event_index: i64,
     pub market_metadata: MarketMetadata,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
@@ -260,6 +263,9 @@ pub struct ChatEvent {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketRegistrationEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    #[serde(serialize_with = "serialize_to_string")]
+    pub event_index: i64,
     pub market_metadata: MarketMetadata,
     #[serde(deserialize_with = "deserialize_from_string")]
     #[serde(serialize_with = "serialize_to_string")]
@@ -574,10 +580,14 @@ impl EventWithMarket {
                 serde_json::from_value(json_data).map(|inner: SwapEvent| Some(Self::Swap(inner)))
             },
             Some(EmojicoinTypeTag::Chat) => {
-                serde_json::from_str(data).map(|inner| Some(Self::Chat(inner)))
+                let mut json_data = serde_json::Value::from_str(data)?;
+                json_data["event_index"] = serde_json::Value::from(event_index.to_string());
+                serde_json::from_value(json_data).map(|inner| Some(Self::Chat(inner)))
             },
             Some(EmojicoinTypeTag::MarketRegistration) => {
-                serde_json::from_str(data).map(|inner| Some(Self::MarketRegistration(inner)))
+                let mut json_data = serde_json::Value::from_str(data)?;
+                json_data["event_index"] = serde_json::Value::from(event_index.to_string());
+                serde_json::from_value(json_data).map(|inner| Some(Self::MarketRegistration(inner)))
             },
             Some(EmojicoinTypeTag::Liquidity) => {
                 let mut json_data = serde_json::Value::from_str(data)?;

--- a/rust/processor/src/db/common/models/emojicoin_models/models/chat_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/chat_event.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 pub struct ChatEventModel {
     // Transaction metadata.
     pub transaction_version: i64,
+    pub event_index: i64,
     pub sender: String,
     pub entry_function: Option<String>,
     pub transaction_timestamp: chrono::NaiveDateTime,
@@ -88,12 +89,14 @@ impl ChatEventModel {
             user_emojicoin_balance,
             circulating_supply,
             balance_as_fraction_of_circulating_supply_q64,
+            event_index,
             ..
         } = chat_event;
 
         ChatEventModel {
             // Transaction metadata.
             transaction_version: txn_info.version,
+            event_index,
             sender: txn_info.sender.clone(),
             entry_function: txn_info.entry_function.clone(),
             transaction_timestamp: txn_info.timestamp,

--- a/rust/processor/src/db/common/models/emojicoin_models/models/market_registration_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/market_registration_event.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 pub struct MarketRegistrationEventModel {
     // Transaction metadata.
     pub transaction_version: i64,
+    pub event_index: i64,
     pub sender: String,
     pub entry_function: Option<String>,
     pub transaction_timestamp: chrono::NaiveDateTime,
@@ -48,12 +49,14 @@ impl MarketRegistrationEventModel {
             registrant,
             integrator,
             integrator_fee,
+            event_index,
             ..
         } = market_registration_event;
 
         MarketRegistrationEventModel {
             // Transaction metadata.
             transaction_version: txn_info.version,
+            event_index,
             sender: txn_info.sender.clone(),
             entry_function: txn_info.entry_function.clone(),
             transaction_timestamp: txn_info.timestamp,

--- a/rust/processor/src/db/postgres/migrations/2025-02-26-040113_add_user_history_indexes/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-02-26-040113_add_user_history_indexes/down.sql
@@ -1,0 +1,15 @@
+-- This file should undo anything in `up.sql`
+
+DROP INDEX IF EXISTS sender_all_swap_hstry_idx;
+DROP INDEX IF EXISTS sender_mkt_swap_hstry_idx;
+DROP INDEX IF EXISTS sender_all_chat_hstry_idx;
+DROP INDEX IF EXISTS sender_mkt_chat_hstry_idx;
+DROP INDEX IF EXISTS sender_all_pool_hstry_idx;
+DROP INDEX IF EXISTS sender_mkt_pool_hstry_idx;
+DROP INDEX IF EXISTS sender_mkt_rgstr_hstry_idx;
+
+
+ALTER TABLE chat_events
+    DROP COLUMN event_index;
+ALTER TABLE market_registration_events
+    DROP COLUMN event_index;

--- a/rust/processor/src/db/postgres/migrations/2025-02-26-040113_add_user_history_indexes/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-02-26-040113_add_user_history_indexes/up.sql
@@ -1,0 +1,143 @@
+-- Your SQL goes here
+
+ALTER TABLE chat_events
+    ADD COLUMN event_index BIGINT NOT NULL;
+ALTER TABLE market_registration_events
+    ADD COLUMN event_index BIGINT NOT NULL;
+    
+-- Why use "sender" and not the event emitted address? Explained below.
+--
+-- For these indexes, "sender" is used as the representation of a user instead
+-- of the emitted fields that represent the interacting account's address;
+-- i.e., the "swapper", "user", "provider", and "registrant". 
+--
+-- Most often, these two fields match; however, objects and resource accounts
+-- are often used in place of the transaction "sender" account as a proxy to
+-- interact with the contract, meaning that the actual user intending to
+-- interact with the contract is often only the "sender" and *not*` the
+-- address in the corresponding event field.
+--
+-- It is possible that this assumption could be wrong, in that the "sender"
+-- and individual "swapper"/"user"/"provider"/"registrant" fields don't match,
+-- but the actual user is *not* the sender but in the fact the one in the event
+-- field. A specific example of this would be if an account (the "sender") signs
+-- and sends a multi-sig script or wrapper contract in which multiple other
+-- accounts sign separate swap/chat/register/liquidity transactions.
+--
+-- However, the difference between "sender" and the corresponding event field
+-- falls under the scope of application logic and is thus left to be dealt
+-- with there, not here.
+
+--------------------------------------------------------------------------------
+
+-- Include all the row data in each index to make the queries much more efficient.
+-- The difference between the two indexes for each table is just that one of them
+-- INCLUDEs `market_id` and the other indexes on it in the composite index, to
+-- facilitate all markets vs per market queries.
+
+CREATE INDEX sender_all_swap_hstry_idx
+ON swap_events (
+    sender,
+    transaction_version,
+    event_index
+) INCLUDE (
+    transaction_timestamp,
+    market_id, -- here.
+    symbol_emojis,
+    is_sell,
+    base_volume,
+    quote_volume,
+    avg_execution_price_q64,
+    in_bonding_curve
+);
+
+CREATE INDEX sender_mkt_swap_hstry_idx
+ON swap_events (
+    sender,
+    market_id, -- here.
+    transaction_version,
+    event_index
+) INCLUDE (
+    transaction_timestamp,
+    symbol_emojis,
+    is_sell,
+    base_volume,
+    quote_volume,
+    avg_execution_price_q64,
+    in_bonding_curve 
+);
+
+CREATE INDEX sender_all_chat_hstry_idx
+ON chat_events (
+    sender,
+    transaction_version,
+    event_index
+) INCLUDE (
+    transaction_timestamp,
+    market_id, -- here.
+    symbol_emojis,
+    "message",
+    user_emojicoin_balance,
+    last_swap_avg_execution_price_q64,
+    in_bonding_curve
+);
+
+CREATE INDEX sender_mkt_chat_hstry_idx
+ON chat_events (
+    sender,
+    market_id, -- here.
+    transaction_version,
+    event_index
+) INCLUDE (
+    transaction_timestamp,
+    symbol_emojis,
+    "message",
+    user_emojicoin_balance,
+    last_swap_avg_execution_price_q64,
+    in_bonding_curve
+);
+
+CREATE INDEX sender_all_pool_hstry_idx
+ON liquidity_events (
+    sender,
+    transaction_version,
+    event_index
+) INCLUDE (
+    transaction_timestamp,
+    market_id, -- here.
+    symbol_emojis,
+    liquidity_provided,
+    base_amount,
+    quote_amount,
+    lp_coin_amount,
+    last_swap_avg_execution_price_q64
+);
+
+CREATE INDEX sender_mkt_pool_hstry_idx
+ON liquidity_events (
+    sender,
+    market_id, -- here.
+    transaction_version,
+    event_index
+) INCLUDE (
+    transaction_timestamp,
+    symbol_emojis,
+    liquidity_provided,
+    base_amount,
+    quote_amount,
+    lp_coin_amount,
+    last_swap_avg_execution_price_q64
+);
+
+-- No need to make two indexes- these are inherently unique for each market.
+CREATE INDEX sender_mkt_rgstr_hstry_idx
+ON market_registration_events (
+    sender,
+    transaction_version,
+    event_index
+) INCLUDE (
+    transaction_timestamp,
+    market_id, -- here.
+    symbol_emojis,
+    market_id
+);

--- a/rust/processor/src/db/postgres/migrations/2025-02-26-040113_add_user_history_indexes/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-02-26-040113_add_user_history_indexes/up.sql
@@ -48,7 +48,7 @@ ON swap_events (
     base_volume,
     quote_volume,
     avg_execution_price_q64,
-    in_bonding_curve
+    lp_coin_supply -- To determine bonding curve status.
 );
 
 CREATE INDEX sender_mkt_swap_hstry_idx
@@ -64,7 +64,7 @@ ON swap_events (
     base_volume,
     quote_volume,
     avg_execution_price_q64,
-    in_bonding_curve 
+    lp_coin_supply -- To determine bonding curve status.
 );
 
 CREATE INDEX sender_all_chat_hstry_idx
@@ -79,7 +79,7 @@ ON chat_events (
     "message",
     user_emojicoin_balance,
     last_swap_avg_execution_price_q64,
-    in_bonding_curve
+    lp_coin_supply -- To determine bonding curve status.
 );
 
 CREATE INDEX sender_mkt_chat_hstry_idx
@@ -94,7 +94,7 @@ ON chat_events (
     "message",
     user_emojicoin_balance,
     last_swap_avg_execution_price_q64,
-    in_bonding_curve
+    lp_coin_supply -- To determine bonding curve status.
 );
 
 CREATE INDEX sender_all_pool_hstry_idx
@@ -138,6 +138,5 @@ ON market_registration_events (
 ) INCLUDE (
     transaction_timestamp,
     market_id, -- here.
-    symbol_emojis,
-    market_id
+    symbol_emojis
 );

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -300,6 +300,7 @@ diesel::table! {
         last_swap_quote_volume -> Numeric,
         last_swap_nonce -> Numeric,
         last_swap_time -> Timestamp,
+        event_index -> Int8,
     }
 }
 
@@ -1234,6 +1235,7 @@ diesel::table! {
         #[max_length = 66]
         integrator -> Varchar,
         integrator_fee -> Numeric,
+        event_index -> Int8,
     }
 }
 


### PR DESCRIPTION
Currently emojicoin-dot-fun includes arena changes. To simply add the new user indexes without pulling in deprecated arena processing code, I'm going to branch off of `v4.0.2` and cherry-pick the non-arena changes.

This is to facilitate cleanly adding this to the production processor without risking using the new arena code in production.

I (and Said) will test this first before using it, on the wallet history page.

The intention is just to add changes to the current production image. Eventually this branch will be obsolete. It's merely to add small changes to the current production processor for the time being