### PR TITLE
feat(ECO-2979): Add block number to market registration events

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/models/market_registration_event.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/market_registration_event.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 pub struct MarketRegistrationEventModel {
     // Transaction metadata.
     pub transaction_version: i64,
+    pub block_number: i64,
     pub event_index: i64,
     pub sender: String,
     pub entry_function: Option<String>,
@@ -56,6 +57,7 @@ impl MarketRegistrationEventModel {
         MarketRegistrationEventModel {
             // Transaction metadata.
             transaction_version: txn_info.version,
+            block_number: txn_info.block_number,
             event_index,
             sender: txn_info.sender.clone(),
             entry_function: txn_info.entry_function.clone(),

--- a/rust/processor/src/db/postgres/migrations/2025-03-04-135523_add_block_number/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-03-04-135523_add_block_number/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE market_registration_events
+        DROP COLUMN block_number;

--- a/rust/processor/src/db/postgres/migrations/2025-03-04-135523_add_block_number/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-03-04-135523_add_block_number/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE market_registration_events
+        ADD COLUMN block_number BIGINT NOT NULL;

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -1279,6 +1279,7 @@ diesel::table! {
         integrator -> Varchar,
         integrator_fee -> Numeric,
         event_index -> Int8,
+        block_number -> Int8,
     }
 }
 


### PR DESCRIPTION
This change is needed for the GeckoTerminal API.