### PR TITLE
feat(ECO-3044): Send entire candlestick to broker instead of diff

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/constants.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/constants.rs
@@ -1,7 +1,7 @@
+use super::enums::Period;
 use lazy_static::lazy_static;
 use std::num::NonZeroU64;
 
-// Only for use below to construct the lazy static strings.
 const SWAP: &str = "::emojicoin_dot_fun::Swap";
 const CHAT: &str = "::emojicoin_dot_fun::Chat";
 const MARKET_REGISTRATION: &str = "::emojicoin_dot_fun::MarketRegistration";
@@ -15,7 +15,26 @@ const ARENA_ENTER: &str = "::emojicoin_arena::Enter";
 const ARENA_EXIT: &str = "::emojicoin_arena::Exit";
 const ARENA_SWAP: &str = "::emojicoin_arena::Swap";
 const ARENA_VAULT_BALANCE_UPDATE: &str = "::emojicoin_arena::VaultBalanceUpdate";
+
 pub const CANDLESTICK_DECIMALS: NonZeroU64 = NonZeroU64::new(16).unwrap();
+pub const NORMAL_CANDLESTICK_PERIODS: [Period; 8] = [
+    Period::FifteenSeconds,
+    Period::OneMinute,
+    Period::FiveMinutes,
+    Period::FifteenMinutes,
+    Period::ThirtyMinutes,
+    Period::OneHour,
+    Period::FourHours,
+    Period::OneDay,
+];
+pub const ARENA_CANDLESTICK_PERIODS: [Period; 6] = [
+    Period::FifteenSeconds,
+    Period::OneMinute,
+    Period::FiveMinutes,
+    Period::FifteenMinutes,
+    Period::ThirtyMinutes,
+    Period::OneHour,
+];
 
 lazy_static! {
     pub static ref MODULE_ADDRESS: String = std::env::var("EMOJICOIN_MODULE_ADDRESS")

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlesticks.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlesticks.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::common::models::emojicoin_models::{
-        constants::CANDLESTICK_DECIMALS,
+        constants::{ARENA_CANDLESTICK_PERIODS, CANDLESTICK_DECIMALS},
         enums::Period,
         json_types::{StateEvent, TxnInfo},
     },
@@ -71,18 +71,9 @@ impl ArenaCandlestickDiffModelBuilder {
         price_0: BigDecimal,
         price_1: BigDecimal,
     ) -> Vec<Self> {
-        let periods = vec![
-            Period::FifteenSeconds,
-            Period::OneMinute,
-            Period::FiveMinutes,
-            Period::FifteenMinutes,
-            Period::ThirtyMinutes,
-            Period::OneHour,
-        ];
-
         let mut candlesticks: Vec<Self> = vec![];
 
-        for period in periods {
+        for &period in ARENA_CANDLESTICK_PERIODS.iter() {
             let start_time = txn_info
                 .timestamp
                 .duration_trunc(period.to_time_delta())

--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlesticks.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_candlesticks.rs
@@ -150,3 +150,33 @@ impl From<ArenaCandlestickDiffModelBuilder> for ArenaCandlestickModel {
         }
     }
 }
+
+pub type AllArenaCandlestickColumns = (
+    BigDecimal,
+    i64,
+    crate::db::common::models::emojicoin_models::enums::Period,
+    chrono::NaiveDateTime,
+    BigDecimal,
+    BigDecimal,
+    BigDecimal,
+    BigDecimal,
+    BigDecimal,
+    BigDecimal,
+);
+
+impl From<AllArenaCandlestickColumns> for ArenaCandlestickModel {
+    fn from(value: AllArenaCandlestickColumns) -> Self {
+        Self {
+            melee_id: value.0,
+            last_transaction_version: value.1,
+            period: value.2,
+            start_time: value.3,
+            open_price: value.4,
+            high_price: value.5,
+            low_price: value.6,
+            close_price: value.7,
+            volume: value.8,
+            n_swaps: value.9,
+        }
+    }
+}

--- a/rust/processor/src/db/common/models/emojicoin_models/models/candlestick.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/candlestick.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::common::models::emojicoin_models::{
-        constants::CANDLESTICK_DECIMALS,
+        constants::{CANDLESTICK_DECIMALS, NORMAL_CANDLESTICK_PERIODS},
         enums::Period,
         json_types::{StateEvent, TxnInfo},
         parsers::emojis::parser::symbol_bytes_to_emojis,
@@ -69,20 +69,9 @@ impl CandlestickDiffModelBuilder {
         state: &StateEvent,
         swap_timestamp: (i64, i64),
     ) -> Vec<Self> {
-        let periods = vec![
-            Period::FifteenSeconds,
-            Period::OneMinute,
-            Period::FiveMinutes,
-            Period::FifteenMinutes,
-            Period::ThirtyMinutes,
-            Period::OneHour,
-            Period::FourHours,
-            Period::OneDay,
-        ];
-
         let mut candlesticks: Vec<Self> = vec![];
 
-        for period in periods {
+        for &period in NORMAL_CANDLESTICK_PERIODS.iter() {
             let start_time = txn_info
                 .timestamp
                 .duration_trunc(period.to_time_delta())
@@ -155,6 +144,36 @@ impl From<CandlestickDiffModelBuilder> for CandlestickModel {
     }
 }
 
+pub type AllCandlestickColumns = (
+    BigDecimal,
+    i64,
+    crate::db::common::models::emojicoin_models::enums::Period,
+    chrono::NaiveDateTime,
+    BigDecimal,
+    BigDecimal,
+    BigDecimal,
+    BigDecimal,
+    Vec<Option<String>>,
+    BigDecimal,
+);
+
+impl From<AllCandlestickColumns> for CandlestickModel {
+    fn from(value: AllCandlestickColumns) -> Self {
+        Self {
+            market_id: value.0,
+            last_transaction_version: value.1,
+            period: value.2,
+            start_time: value.3,
+            open_price: value.4,
+            high_price: value.5,
+            low_price: value.6,
+            close_price: value.7,
+            symbol_emojis: value.8.into_iter().map(Option::unwrap).collect(),
+            volume: value.9,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -171,7 +190,7 @@ mod tests {
             last_transaction_version: 12,
 
             period: Period::OneMinute,
-            start_time: start_time.clone(),
+            start_time,
 
             open_price: BigDecimal::from(50),
             high_price: BigDecimal::from(50),
@@ -190,7 +209,7 @@ mod tests {
             last_transaction_version: 15,
 
             period: Period::OneMinute,
-            start_time: start_time.clone(),
+            start_time,
 
             open_price: BigDecimal::from(40),
             high_price: BigDecimal::from(40),
@@ -210,7 +229,7 @@ mod tests {
             last_transaction_version: 15,
 
             period: Period::OneHour,
-            start_time: start_time.clone(),
+            start_time,
 
             open_price: BigDecimal::from(40),
             high_price: BigDecimal::from(40),
@@ -231,7 +250,6 @@ mod tests {
 
             period: Period::OneMinute,
             start_time: start_time
-                .clone()
                 .checked_add_signed(TimeDelta::minutes(1))
                 .unwrap(),
 
@@ -253,7 +271,7 @@ mod tests {
             last_transaction_version: 15,
 
             period: Period::OneMinute,
-            start_time: start_time.clone(),
+            start_time,
 
             open_price: BigDecimal::from(40),
             high_price: BigDecimal::from(40),
@@ -347,7 +365,7 @@ mod tests {
             last_transaction_version: 12,
 
             period: Period::OneMinute,
-            start_time: start_time.clone(),
+            start_time,
 
             open_price: BigDecimal::from(50),
             high_price: BigDecimal::from(50),
@@ -377,35 +395,5 @@ mod tests {
         assert_eq!(candlestick.close_price, builder.close_price);
         assert_eq!(candlestick.symbol_emojis, builder.symbol_emojis);
         assert_eq!(candlestick.volume, builder.volume);
-    }
-}
-
-pub type AllCandlestickColumns = (
-    BigDecimal,
-    i64,
-    crate::db::common::models::emojicoin_models::enums::Period,
-    chrono::NaiveDateTime,
-    BigDecimal,
-    BigDecimal,
-    BigDecimal,
-    BigDecimal,
-    Vec<Option<String>>,
-    BigDecimal,
-);
-
-impl From<AllCandlestickColumns> for CandlestickModel {
-    fn from(value: AllCandlestickColumns) -> Self {
-        Self {
-            market_id: value.0,
-            last_transaction_version: value.1,
-            period: value.2,
-            start_time: value.3,
-            open_price: value.4,
-            high_price: value.5,
-            low_price: value.6,
-            close_price: value.7,
-            symbol_emojis: value.8.into_iter().map(Option::unwrap).collect(),
-            volume: value.9,
-        }
     }
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/models/candlestick.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/candlestick.rs
@@ -379,3 +379,33 @@ mod tests {
         assert_eq!(candlestick.volume, builder.volume);
     }
 }
+
+pub type AllCandlestickColumns = (
+    BigDecimal,
+    i64,
+    crate::db::common::models::emojicoin_models::enums::Period,
+    chrono::NaiveDateTime,
+    BigDecimal,
+    BigDecimal,
+    BigDecimal,
+    BigDecimal,
+    Vec<Option<String>>,
+    BigDecimal,
+);
+
+impl From<AllCandlestickColumns> for CandlestickModel {
+    fn from(value: AllCandlestickColumns) -> Self {
+        Self {
+            market_id: value.0,
+            last_transaction_version: value.1,
+            period: value.2,
+            start_time: value.3,
+            open_price: value.4,
+            high_price: value.5,
+            low_price: value.6,
+            close_price: value.7,
+            symbol_emojis: value.8.into_iter().map(Option::unwrap).collect(),
+            volume: value.9,
+        }
+    }
+}

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
@@ -393,83 +393,102 @@ pub fn insert_arena_vault_balance_update_events_query(
     )
 }
 
-pub fn insert_arena_candlesticks_query(
-    items_to_insert: Vec<ArenaCandlestickModel>,
-) -> (
-    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
-    Option<&'static str>,
-) {
-    use schema::arena_candlesticks::dsl::*;
-    (
-        diesel::insert_into(schema::arena_candlesticks::table)
-            .values(items_to_insert)
-            .on_conflict((melee_id, period, start_time))
-            .do_update()
-            .set((
-                last_transaction_version.eq(excluded(last_transaction_version)),
-                open_price.eq(sql("COALESCE(")
-                    .bind(open_price)
-                    .sql(",")
-                    .bind(excluded(open_price))
-                    .sql(")")),
-                high_price.eq(sql("GREATEST(COALESCE(")
-                    .bind(high_price)
-                    .sql(",")
-                    .bind(excluded(high_price))
-                    .sql("),")
-                    .bind(excluded(high_price))
-                    .sql(")")),
-                low_price.eq(sql("LEAST(COALESCE(")
-                    .bind(low_price)
-                    .sql(",")
-                    .bind(excluded(low_price))
-                    .sql("),")
-                    .bind(excluded(low_price))
-                    .sql(")")),
-                close_price.eq(excluded(close_price)),
-                volume.eq(volume + excluded(volume)),
-                n_swaps.eq(n_swaps + excluded(n_swaps)),
-            )),
-        None,
-    )
-}
+pub mod run_queries {
+    //! Due to the way diesel types queries, it is not possilbe to use an insert query that has a
+    //! [`diesel::query_builder::InsertStatement::returning`] clause with the helper functions
+    //! declared in the [`crate::utils::database`] module. For that reason, those queries are
+    //! isolated in this [`run_queries`] module.
 
-pub fn insert_candlesticks_query(
-    items_to_insert: Vec<CandlestickModel>,
-) -> (
-    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
-    Option<&'static str>,
-) {
-    use schema::candlesticks::dsl::*;
-    (
-        diesel::insert_into(schema::candlesticks::table)
-            .values(items_to_insert)
-            .on_conflict((market_id, period, start_time))
-            .do_update()
-            .set((
-                last_transaction_version.eq(excluded(last_transaction_version)),
-                open_price.eq(sql("COALESCE(")
-                    .bind(open_price)
-                    .sql(",")
-                    .bind(excluded(open_price))
-                    .sql(")")),
-                high_price.eq(sql("GREATEST(COALESCE(")
-                    .bind(high_price)
-                    .sql(",")
-                    .bind(excluded(high_price))
-                    .sql("),")
-                    .bind(excluded(high_price))
-                    .sql(")")),
-                low_price.eq(sql("LEAST(COALESCE(")
-                    .bind(low_price)
-                    .sql(",")
-                    .bind(excluded(low_price))
-                    .sql("),")
-                    .bind(excluded(low_price))
-                    .sql(")")),
-                close_price.eq(excluded(close_price)),
-                volume.eq(volume + excluded(volume)),
-            )),
-        None,
-    )
+    use crate::{db::common::models::emojicoin_models::models::prelude::*, schema};
+    use diesel::{dsl::sql, upsert::excluded, ExpressionMethods};
+    use diesel_async::{pooled_connection::bb8::PooledConnection, AsyncPgConnection, RunQueryDsl};
+
+    pub async fn insert_arena_candlesticks_query(
+        conn: &mut PooledConnection<'_, AsyncPgConnection>,
+        items_to_insert: Vec<ArenaCandlestickModel>,
+        chunk_size: usize,
+    ) -> Result<Vec<ArenaCandlestickModel>, diesel::result::Error> {
+        use schema::arena_candlesticks::dsl::*;
+        let mut res = vec![];
+        for chunk in items_to_insert.chunks(chunk_size) {
+            let r = diesel::insert_into(schema::arena_candlesticks::table)
+                .values(chunk)
+                .on_conflict((melee_id, period, start_time))
+                .do_update()
+                .set((
+                    last_transaction_version.eq(excluded(last_transaction_version)),
+                    open_price.eq(sql("COALESCE(")
+                        .bind(open_price)
+                        .sql(",")
+                        .bind(excluded(open_price))
+                        .sql(")")),
+                    high_price.eq(sql("GREATEST(COALESCE(")
+                        .bind(high_price)
+                        .sql(",")
+                        .bind(excluded(high_price))
+                        .sql("),")
+                        .bind(excluded(high_price))
+                        .sql(")")),
+                    low_price.eq(sql("LEAST(COALESCE(")
+                        .bind(low_price)
+                        .sql(",")
+                        .bind(excluded(low_price))
+                        .sql("),")
+                        .bind(excluded(low_price))
+                        .sql(")")),
+                    close_price.eq(excluded(close_price)),
+                    volume.eq(volume + excluded(volume)),
+                    n_swaps.eq(n_swaps + excluded(n_swaps)),
+                ))
+                .returning(schema::arena_candlesticks::all_columns)
+                .get_results::<AllArenaCandlestickColumns>(conn)
+                .await?;
+            res.extend(r);
+        }
+        Ok(res.into_iter().map(|e| e.into()).collect())
+    }
+
+    pub async fn insert_candlesticks_query(
+        conn: &mut PooledConnection<'_, AsyncPgConnection>,
+        items_to_insert: Vec<CandlestickModel>,
+        chunk_size: usize,
+    ) -> Result<Vec<CandlestickModel>, diesel::result::Error> {
+        use schema::candlesticks::dsl::*;
+        let mut res = vec![];
+        for chunk in items_to_insert.chunks(chunk_size) {
+            let r = diesel::insert_into(schema::candlesticks::table)
+                .values(chunk)
+                .on_conflict((market_id, period, start_time))
+                .do_update()
+                .set((
+                    last_transaction_version.eq(excluded(last_transaction_version)),
+                    open_price.eq(sql("COALESCE(")
+                        .bind(open_price)
+                        .sql(",")
+                        .bind(excluded(open_price))
+                        .sql(")")),
+                    high_price.eq(sql("GREATEST(COALESCE(")
+                        .bind(high_price)
+                        .sql(",")
+                        .bind(excluded(high_price))
+                        .sql("),")
+                        .bind(excluded(high_price))
+                        .sql(")")),
+                    low_price.eq(sql("LEAST(COALESCE(")
+                        .bind(low_price)
+                        .sql(",")
+                        .bind(excluded(low_price))
+                        .sql("),")
+                        .bind(excluded(low_price))
+                        .sql(")")),
+                    close_price.eq(excluded(close_price)),
+                    volume.eq(volume + excluded(volume)),
+                ))
+                .returning(schema::candlesticks::all_columns)
+                .get_results::<AllCandlestickColumns>(conn)
+                .await?;
+            res.extend(r);
+        }
+        Ok(res.into_iter().map(|e| e.into()).collect())
+    }
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/queries/insertion_queries.rs
@@ -394,10 +394,33 @@ pub fn insert_arena_vault_balance_update_events_query(
 }
 
 pub mod run_queries {
-    //! Due to the way diesel types queries, it is not possilbe to use an insert query that has a
+    //! Due to the way diesel types queries, it's not possible to use an insert query that has a
     //! [`diesel::query_builder::InsertStatement::returning`] clause with the helper functions
     //! declared in the [`crate::utils::database`] module. For that reason, those queries are
     //! isolated in this [`run_queries`] module.
+
+    macro_rules! coalesce {
+        // coalesce!(open) -> COALESCE(open, excluded(open))
+        ($column:expr) => {
+            sql("COALESCE(")
+                .bind($column)
+                .sql(",")
+                .bind(excluded($column))
+                .sql(")")
+        };
+
+        // coalesce!("GREATEST", high) -> GREATEST(COALESCE(high, excluded(high)))
+        // coalesce!("LEAST", low)     -> LEAST(COALESCE(low, excluded(low)))
+        ($operation:expr, $column:expr) => {
+            sql(concat!($operation, "(COALESCE("))
+                .bind($column)
+                .sql(",")
+                .bind(excluded($column))
+                .sql("),")
+                .bind(excluded($column))
+                .sql(")")
+        };
+    }
 
     use crate::{db::common::models::emojicoin_models::models::prelude::*, schema};
     use diesel::{dsl::sql, upsert::excluded, ExpressionMethods};
@@ -417,25 +440,9 @@ pub mod run_queries {
                 .do_update()
                 .set((
                     last_transaction_version.eq(excluded(last_transaction_version)),
-                    open_price.eq(sql("COALESCE(")
-                        .bind(open_price)
-                        .sql(",")
-                        .bind(excluded(open_price))
-                        .sql(")")),
-                    high_price.eq(sql("GREATEST(COALESCE(")
-                        .bind(high_price)
-                        .sql(",")
-                        .bind(excluded(high_price))
-                        .sql("),")
-                        .bind(excluded(high_price))
-                        .sql(")")),
-                    low_price.eq(sql("LEAST(COALESCE(")
-                        .bind(low_price)
-                        .sql(",")
-                        .bind(excluded(low_price))
-                        .sql("),")
-                        .bind(excluded(low_price))
-                        .sql(")")),
+                    open_price.eq(coalesce!(open_price)),
+                    high_price.eq(coalesce!("GREATEST", high_price)),
+                    low_price.eq(coalesce!("LEAST", low_price)),
                     close_price.eq(excluded(close_price)),
                     volume.eq(volume + excluded(volume)),
                     n_swaps.eq(n_swaps + excluded(n_swaps)),
@@ -462,25 +469,9 @@ pub mod run_queries {
                 .do_update()
                 .set((
                     last_transaction_version.eq(excluded(last_transaction_version)),
-                    open_price.eq(sql("COALESCE(")
-                        .bind(open_price)
-                        .sql(",")
-                        .bind(excluded(open_price))
-                        .sql(")")),
-                    high_price.eq(sql("GREATEST(COALESCE(")
-                        .bind(high_price)
-                        .sql(",")
-                        .bind(excluded(high_price))
-                        .sql("),")
-                        .bind(excluded(high_price))
-                        .sql(")")),
-                    low_price.eq(sql("LEAST(COALESCE(")
-                        .bind(low_price)
-                        .sql(",")
-                        .bind(excluded(low_price))
-                        .sql("),")
-                        .bind(excluded(low_price))
-                        .sql(")")),
+                    open_price.eq(coalesce!(open_price)),
+                    high_price.eq(coalesce!("GREATEST", high_price)),
+                    low_price.eq(coalesce!("LEAST", low_price)),
                     close_price.eq(excluded(close_price)),
                     volume.eq(volume + excluded(volume)),
                 ))

--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -191,7 +191,7 @@ async fn insert_to_db(
     insert_events: InsertEvents,
     per_table_chunk_sizes: &AHashMap<String, usize>,
     max_transaction_version: u64,
-) -> Result<(), diesel::result::Error> {
+) -> Result<(Vec<CandlestickModel>, Vec<ArenaCandlestickModel>), diesel::result::Error> {
     tracing::trace!(
         name = name,
         start_version = start_version,
@@ -394,20 +394,18 @@ async fn insert_to_db(
                 ),
             )
             .await?;
-            execute_in_transaction(
+            let arena_candlesticks = run_queries::insert_arena_candlesticks_query(
                 conn,
-                insert_arena_candlesticks_query,
-                &arena_candlesticks,
+                arena_candlesticks,
                 get_config_table_chunk_size::<ArenaCandlestickModel>(
                     "arena_candlesticks",
                     per_table_chunk_sizes,
                 ),
             )
             .await?;
-            execute_in_transaction(
+            let candlesticks = run_queries::insert_candlesticks_query(
                 conn,
-                insert_candlesticks_query,
-                &candlesticks,
+                candlesticks,
                 get_config_table_chunk_size::<CandlestickModel>(
                     "candlesticks",
                     per_table_chunk_sizes,
@@ -443,13 +441,14 @@ async fn insert_to_db(
                     .await?;
             }
 
-            Ok::<(), diesel::result::Error>(())
+            Ok::<(Vec<CandlestickModel>, Vec<ArenaCandlestickModel>), diesel::result::Error>((
+                candlesticks,
+                arena_candlesticks,
+            ))
         }
         .scope_boxed()
     })
-    .await?;
-
-    Ok(())
+    .await
 }
 
 struct MarketData {
@@ -1065,7 +1064,7 @@ impl ProcessorTrait for EmojicoinProcessor {
         let processing_duration_in_secs = processing_start.elapsed().as_secs_f64();
         let db_insertion_start = std::time::Instant::now();
 
-        let all_db_events = vec![
+        let mut all_db_events = vec![
             EmojicoinDbEvent::from_market_registration_events(
                 &insert_events.market_registration_events,
             ),
@@ -1084,14 +1083,10 @@ impl ProcessorTrait for EmojicoinProcessor {
             EmojicoinDbEvent::from_arena_vault_balance_update(
                 &insert_events.arena_vault_balance_update_events,
             ),
-            EmojicoinDbEvent::from_arena_candlesticks(&insert_events.arena_candlesticks),
-            EmojicoinDbEvent::from_candlesticks(&insert_events.candlesticks),
         ]
         .into_iter()
         .flatten()
         .collect_vec();
-
-        self.publish_events(all_db_events);
 
         let tx_result = insert_to_db(
             pool,
@@ -1106,7 +1101,12 @@ impl ProcessorTrait for EmojicoinProcessor {
 
         let db_insertion_duration_in_secs = db_insertion_start.elapsed().as_secs_f64();
         match tx_result {
-            Ok(_) => {
+            Ok((candlesticks, arena_candlesticks)) => {
+                all_db_events.extend(EmojicoinDbEvent::from_arena_candlesticks(
+                    &arena_candlesticks,
+                ));
+                all_db_events.extend(EmojicoinDbEvent::from_candlesticks(&candlesticks));
+                self.publish_events(all_db_events);
                 *self.version.write().await = max_transaction_version;
                 let res = ProcessingResult::DefaultProcessingResult(DefaultProcessingResult {
                     start_version,

--- a/rust/processor/src/utils/util.rs
+++ b/rust/processor/src/utils/util.rs
@@ -417,20 +417,14 @@ pub fn convert_bcs_hex_new(typ: u8, value: String) -> Option<String> {
 /// Convert the json serialized PropertyMap's inner BCS fields to their original value in string format
 pub fn convert_bcs_propertymap(s: Value) -> Option<Value> {
     match PropertyMap::from_bcs_encode_str(s) {
-        Some(e) => match serde_json::to_value(&e) {
-            Ok(val) => Some(val),
-            Err(_) => None,
-        },
+        Some(e) => serde_json::to_value(&e).ok(),
         None => None,
     }
 }
 
 pub fn convert_bcs_token_object_propertymap(s: Value) -> Option<Value> {
     match TokenObjectPropertyMap::from_bcs_encode_str(s) {
-        Some(e) => match serde_json::to_value(&e) {
-            Ok(val) => Some(val),
-            Err(_) => None,
-        },
+        Some(e) => serde_json::to_value(&e).ok(),
         None => None,
     }
 }


### PR DESCRIPTION
This PR makes it so that instead of sending the latest candlestick diff to the broker (and thus the frontend), it sends an entire candlestick.