### PR TITLE
fix(ECO-3142): Fix restart issue

### DIFF
--- a/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
+++ b/rust/processor/src/processors/emojicoin_dot_fun/processor.rs
@@ -1000,7 +1000,7 @@ impl ProcessorTrait for EmojicoinProcessor {
         let mut market_registrations = vec![];
         let mut states: AHashMap<BigDecimal, StateEvent> = AHashMap::new();
 
-        let mut max_transaction_version = 0;
+        let mut max_transaction_version = prev_last_success_version;
 
         for txn in &transactions {
             max_transaction_version = std::cmp::max(max_transaction_version, txn.version);


### PR DESCRIPTION
The emojicoin highest processed transaction version was getting reset to a lower version when the processor restarted. That led to events being inserted twice. This is now fixed by never allowing the highest processed version to go lower than what it previously was.