### PR TITLE
chore(ECO-3162): Expose the last transaction versions to leaderboard history view

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2025-04-02-191340_add_last_txn_versions_to_leaderboard_view/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-04-02-191340_add_last_txn_versions_to_leaderboard_view/down.sql
@@ -1,0 +1,30 @@
+-- This file should undo anything in `up.sql`
+
+DROP VIEW arena_leaderboard_history_with_arena_info;
+
+CREATE VIEW arena_leaderboard_history_with_arena_info AS
+SELECT
+    arena_leaderboard_history.user,
+    arena_leaderboard_history.melee_id,
+    arena_leaderboard_history.profits,
+    arena_leaderboard_history.losses,
+    arena_leaderboard_history.withdrawals,
+    arena_leaderboard_history.emojicoin_0_balance,
+    arena_leaderboard_history.emojicoin_1_balance,
+    arena_leaderboard_history.exited,
+    arena_leaderboard_history.last_exit_0,
+
+    arena_info.emojicoin_0_symbols,
+    arena_info.emojicoin_1_symbols,
+    arena_info.emojicoin_0_market_address,
+    arena_info.emojicoin_1_market_address,
+    arena_info.emojicoin_0_market_id,
+    arena_info.emojicoin_1_market_id,
+    arena_info.start_time,
+    arena_info.duration
+FROM
+    arena_leaderboard_history
+INNER JOIN
+    arena_info
+ON
+    arena_info.melee_id = arena_leaderboard_history.melee_id;

--- a/rust/processor/src/db/postgres/migrations/2025-04-02-191340_add_last_txn_versions_to_leaderboard_view/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-04-02-191340_add_last_txn_versions_to_leaderboard_view/up.sql
@@ -1,0 +1,34 @@
+-- Your SQL goes here
+
+DROP VIEW IF EXISTS arena_leaderboard_history_with_arena_info;
+
+CREATE OR REPLACE VIEW arena_leaderboard_history_with_arena_info AS
+SELECT
+    arena_leaderboard_history.user,
+    arena_leaderboard_history.melee_id,
+    arena_leaderboard_history.profits,
+    arena_leaderboard_history.losses,
+    arena_leaderboard_history.withdrawals,
+    arena_leaderboard_history.emojicoin_0_balance,
+    arena_leaderboard_history.emojicoin_1_balance,
+    arena_leaderboard_history.exited,
+    arena_leaderboard_history.last_exit_0,
+    -- This is one of the two new columns. Nothing else changes in this view.
+    arena_leaderboard_history.last_transaction_version AS leaderboard_last_transaction_version,
+
+    arena_info.emojicoin_0_symbols,
+    arena_info.emojicoin_1_symbols,
+    arena_info.emojicoin_0_market_address,
+    arena_info.emojicoin_1_market_address,
+    arena_info.emojicoin_0_market_id,
+    arena_info.emojicoin_1_market_id,
+    arena_info.start_time,
+    arena_info.duration,
+    -- This is one of the two new columns. Nothing else changes in this view.
+    arena_info.last_transaction_version AS arena_info_last_transaction_version
+FROM
+    arena_leaderboard_history
+INNER JOIN
+    arena_info
+ON
+    arena_info.melee_id = arena_leaderboard_history.melee_id;

--- a/rust/processor/src/db/postgres/migrations/2025-04-02-191340_add_last_txn_versions_to_leaderboard_view/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-04-02-191340_add_last_txn_versions_to_leaderboard_view/up.sql
@@ -13,8 +13,6 @@ SELECT
     arena_leaderboard_history.emojicoin_1_balance,
     arena_leaderboard_history.exited,
     arena_leaderboard_history.last_exit_0,
-    -- This is one of the two new columns. Nothing else changes in this view.
-    arena_leaderboard_history.last_transaction_version AS leaderboard_last_transaction_version,
 
     arena_info.emojicoin_0_symbols,
     arena_info.emojicoin_1_symbols,
@@ -24,7 +22,9 @@ SELECT
     arena_info.emojicoin_1_market_id,
     arena_info.start_time,
     arena_info.duration,
-    -- This is one of the two new columns. Nothing else changes in this view.
+
+    -- The two new columns.
+    arena_leaderboard_history.last_transaction_version AS leaderboard_history_last_transaction_version,
     arena_info.last_transaction_version AS arena_info_last_transaction_version
 FROM
     arena_leaderboard_history


### PR DESCRIPTION
# Description

The last transaction version fields were added later and thus not included in the original view function definition, despite being there for both the tables that comprise the view data.

### Why?

To make sure we don't display stale data in the frontend, we have to know the transaction version for any data queried.

### Changes

Simply expose them with a simple diesel migration.

- [x] Add `down.sql` (just recreates the same exact view as before)
- [x] Add `up.sql` (just exposes two new columns with more specific names)

# Testing

- [x] Build and test it locally, as well as with an `rc-#` tag to test it in the SDK/frontend.

