### PR TITLE
fix(ECO-3165): Fix diesel migrations and update `schema.rs` for normal candlesticks

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/models/candlestick.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/candlestick.rs
@@ -29,9 +29,9 @@ pub struct CandlestickDiffModelBuilder {
     pub open_timestamp: (i64, i64),
     pub close_timestamp: (i64, i64),
 
-    pub symbol_emojis: Vec<String>,
-
     pub volume: BigDecimal,
+
+    pub symbol_emojis: Vec<String>,
 }
 
 impl CandlestickDiffModelBuilder {
@@ -112,9 +112,9 @@ pub struct CandlestickModel {
     pub low_price: BigDecimal,
     pub close_price: BigDecimal,
 
-    pub symbol_emojis: Vec<String>,
-
     pub volume: BigDecimal,
+
+    pub symbol_emojis: Vec<String>,
 }
 
 impl CandlestickModel {
@@ -137,9 +137,9 @@ impl From<CandlestickDiffModelBuilder> for CandlestickModel {
             low_price: Self::truncate(value.low_price),
             close_price: Self::truncate(value.close_price),
 
-            symbol_emojis: value.symbol_emojis,
-
             volume: value.volume,
+
+            symbol_emojis: value.symbol_emojis,
         }
     }
 }
@@ -153,8 +153,8 @@ pub type AllCandlestickColumns = (
     BigDecimal,
     BigDecimal,
     BigDecimal,
-    Vec<Option<String>>,
     BigDecimal,
+    Vec<Option<String>>,
 );
 
 impl From<AllCandlestickColumns> for CandlestickModel {
@@ -168,8 +168,8 @@ impl From<AllCandlestickColumns> for CandlestickModel {
             high_price: value.5,
             low_price: value.6,
             close_price: value.7,
-            symbol_emojis: value.8.into_iter().map(Option::unwrap).collect(),
-            volume: value.9,
+            volume: value.8,
+            symbol_emojis: value.9.into_iter().map(Option::unwrap).collect(),
         }
     }
 }

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -290,6 +290,24 @@ diesel::table! {
 
 diesel::table! {
     use diesel::sql_types::*;
+    use super::sql_types::PeriodType;
+
+    candlesticks (market_id, period, start_time) {
+        market_id -> Numeric,
+        last_transaction_version -> Int8,
+        period -> PeriodType,
+        start_time -> Timestamp,
+        open_price -> Numeric,
+        high_price -> Numeric,
+        low_price -> Numeric,
+        close_price -> Numeric,
+        volume -> Numeric,
+        symbol_emojis -> Array<Nullable<Text>>,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
     use super::sql_types::TriggerType;
 
     chat_events (market_id, market_nonce) {
@@ -1333,24 +1351,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    use diesel::sql_types::*;
-    use super::sql_types::PeriodType;
-
-    candlesticks (market_id, period, start_time) {
-        market_id -> Numeric,
-        last_transaction_version -> Int8,
-        period -> PeriodType,
-        start_time -> Timestamp,
-        open_price -> Numeric,
-        high_price -> Numeric,
-        low_price -> Numeric,
-        close_price -> Numeric,
-        symbol_emojis -> Array<Nullable<Text>>,
-        volume -> Numeric,
-    }
-}
-
-diesel::table! {
     objects (transaction_version, write_set_change_index) {
         transaction_version -> Int8,
         write_set_change_index -> Int8,
@@ -1875,6 +1875,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     arena_swap_events,
     arena_vault_balance_update_events,
     block_metadata_transactions,
+    candlesticks,
     chat_events,
     coin_activities,
     coin_balances,
@@ -1925,7 +1926,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     move_modules,
     move_resources,
     nft_points,
-    candlesticks,
     objects,
     periodic_state_events,
     processor_status,


### PR DESCRIPTION
# Description

This issue was found in #116 during pre-commit, since I had to run `diesel migration redo --all` to re-generate the schema. `cargo check` failed in `pre-commit` and I investigated as to why.

The diesel migration for the `candlesticks` `up.sql` was not run the last time it was updated- so the columns were out of order.

Since the diff in this file shows the order of the tables going from 

```
    nft_points,
    candlesticks,
    objects,

to

    block_metadata_transactions,
    candlesticks,
    chat_events,
```

It seems like the `schema.rs` was hand-edited to update the table name, thus missing the new column ordering and causing an invalid schema to be used by diesel.

This seemingly runs fine despite the discrepancy due to it being an compile time issue, solely because of the fact that `diesel` generates the SQL code with column names, meaning `... symbol_emojis, volume` insertions will work just as well as the proper `... volume, symbol_emojis` insertions will