### PR TITLE
fix(ECO-3190): Fix rewards remaining calculation

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/models/arena_info.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/models/arena_info.rs
@@ -117,7 +117,7 @@ impl From<ArenaExitEventModel> for ArenaInfoDiffUpdate {
             melee_id: value.melee_id,
             last_transaction_version: value.transaction_version,
             volume: BigDecimal::zero(),
-            rewards_remaining: -value.tap_out_fee,
+            rewards_remaining: value.tap_out_fee,
             emojicoin_0_locked: -value.emojicoin_0_proceeds,
             emojicoin_1_locked: -value.emojicoin_1_proceeds,
         }


### PR DESCRIPTION
- [x] The diff was applying the tap out fee the wrong way; it needs to add it, not subtract it from the total rewards remaining
- [ ] Create 7.0.4 tag after merging this

Found it by testing and watching the view function result vs the indexer result:

```json
aptos move view --function-id food::emojicoin_arena::melee --args u64:47 --profile food
{
  "Result": [
    {
      "available_rewards": "99962737934",
      // ...
    }
  ]
}
aptos move view --function-id food::emojicoin_arena::melee --args u64:47 --profile food
{
  "Result": [
    {
      "available_rewards": "100000000000",
      // ...
    }
  ]
}
```

whereas the db, for the same two txns:

```sql
emojicoin=# SELECT * FROM arena_info ORDER BY melee_id DESC LIMIT 1;
-[ RECORD 1 ]--------------+-------------------------------------------------------------------
melee_id                   | 47
last_transaction_version   | 39562
rewards_remaining          | 99962737934
-- ...

emojicoin=# SELECT * FROM arena_info ORDER BY melee_id DESC LIMIT 1;
-[ RECORD 1 ]--------------+-------------------------------------------------------------------
melee_id                   | 47
last_transaction_version   | 39603
rewards_remaining          | 99925475868
-- ...
```

notice how in the 2nd one for the view function result, the view function goes back up (because it adds the tap out fee back) whereas in the db result, the rewards remaining decrements by the tap_out fee