### PR TITLE
chore(ECO-3232): Make terminology for move modules consistent

### DIFF
--- a/rust/processor/src/db/common/models/emojicoin_models/constants.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/constants.rs
@@ -74,11 +74,11 @@ mod tests {
     use crate::utils::util::standardize_address;
 
     #[test]
-    fn ensure_contract_address_is_standardized() {
+    fn ensure_module_address_is_standardized() {
         if standardize_address(env!("EMOJICOIN_MODULE_ADDRESS")) != env!("EMOJICOIN_MODULE_ADDRESS")
         {
             panic!(
-                "The non-standardized contract address: {} is invalid because it doesn't match the standardized address: {}",
+                "The non-standardized module address: {} is invalid because it doesn't match the standardized address: {}",
                 env!("EMOJICOIN_MODULE_ADDRESS"),
                 standardize_address(env!("EMOJICOIN_MODULE_ADDRESS"))
             );

--- a/rust/processor/src/db/common/models/emojicoin_models/enums.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/enums.rs
@@ -189,7 +189,7 @@ pub enum EmojicoinDbEvent {
     ArenaExit(ArenaExitEventModel),
     ArenaSwap(ArenaSwapEventModel),
     ArenaVaultBalanceUpdate(ArenaVaultBalanceUpdateEventModel),
-    // Not an actual event in the move Module- but is sent to the broker.
+    // Not an actual event in the Move module- but is sent to the broker.
     ArenaCandlestick(ArenaCandlestickModel),
     Candlestick(CandlestickModel),
 }

--- a/rust/processor/src/db/common/models/emojicoin_models/enums.rs
+++ b/rust/processor/src/db/common/models/emojicoin_models/enums.rs
@@ -189,7 +189,7 @@ pub enum EmojicoinDbEvent {
     ArenaExit(ArenaExitEventModel),
     ArenaSwap(ArenaSwapEventModel),
     ArenaVaultBalanceUpdate(ArenaVaultBalanceUpdateEventModel),
-    // Not an actual event in the contract- but is sent to the broker.
+    // Not an actual event in the move Module- but is sent to the broker.
     ArenaCandlestick(ArenaCandlestickModel),
     Candlestick(CandlestickModel),
 }
@@ -224,7 +224,7 @@ pub enum EmojicoinDbEventType {
     ArenaExit,
     ArenaSwap,
     ArenaVaultBalanceUpdate,
-    // Not an actual event in the contract- but is sent to the broker.
+    // Not an actual event in the Move module- but is sent to the broker.
     ArenaCandlestick,
     Candlestick,
 }

--- a/rust/processor/src/db/postgres/migrations/2025-02-26-040113_add_user_history_indexes/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-02-26-040113_add_user_history_indexes/up.sql
@@ -13,15 +13,15 @@ ALTER TABLE market_registration_events
 --
 -- Most often, these two fields match; however, objects and resource accounts
 -- are often used in place of the transaction "sender" account as a proxy to
--- interact with the contract, meaning that the actual user intending to
--- interact with the contract is often only the "sender" and *not*` the
+-- interact with the module, meaning that the actual user intending to
+-- interact with the module is often only the "sender" and *not*` the
 -- address in the corresponding event field.
 --
 -- It is possible that this assumption could be wrong, in that the "sender"
 -- and individual "swapper"/"user"/"provider"/"registrant" fields don't match,
 -- but the actual user is *not* the sender but in the fact the one in the event
 -- field. A specific example of this would be if an account (the "sender") signs
--- and sends a multi-sig script or wrapper contract in which multiple other
+-- and sends a multi-sig script or wrapper module in which multiple other
 -- accounts sign separate swap/chat/register/liquidity transactions.
 --
 -- However, the difference between "sender" and the corresponding event field


### PR DESCRIPTION
Make any references to `contract` reflect consistent terminology by replacing it with `module` or `Move module`. Everywhere in this fork
