### PR TITLE
fix(ECO-3284): Use `market_state` instead of `market_latest_state_event` in the final `price_feed` view

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2025-05-01-025837_optimize_price_feed/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-05-01-025837_optimize_price_feed/up.sql
@@ -54,7 +54,7 @@ with_prices AS (
         END AS open_price_q64,
         latest_swap.last_swap_avg_execution_price_q64 AS close_price_q64
     FROM markets
-    INNER JOIN market_latest_state_event AS latest_swap ON markets.market_id = latest_swap.market_id
+    INNER JOIN market_state AS latest_swap ON markets.market_id = latest_swap.market_id
     LEFT JOIN swap24 AS swap_open ON markets.market_id = swap_open.market_id
     WHERE latest_swap.transaction_timestamp > CURRENT_TIMESTAMP - interval '1 day'
 )


### PR DESCRIPTION
# Description

I removed it earlier thinking it was necessary to optimize the query, but it doesn't impact query performance at all (since we properly filter out markets without daily volume now early in the query).

Keeping the types the same by using `market_state` (the query with daily volume and other misc fields) is much simpler.

- [x] Use `market_state` instead of `market_latest_state_event`
- [x] Manually edit the `up.sql` since the image hasn't merged to any stack yet
- [x] Rebuild with the updated patch bumped tag, since it's more of a fix than a feature or anything else.