### PR TITLE
refactor(ECO-3301): Optimize stats queries

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2025-05-01-025837_optimize_price_feed/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-05-01-025837_optimize_price_feed/down.sql
@@ -1,9 +1,8 @@
 -- This file should undo anything in `up.sql`
 -- Your SQL goes here
-DROP FUNCTION price_feed;
-ALTER INDEX price_feed RENAME TO price_feed_idx;
+DROP VIEW IF EXISTS price_feed;
 
-CREATE OR REPLACE VIEW price_feed AS
+CREATE VIEW price_feed AS
 WITH markets AS (
     SELECT market_id
     FROM market_state

--- a/rust/processor/src/db/postgres/migrations/2025-05-21-212304_optimize_stats_queries/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-05-21-212304_optimize_stats_queries/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+
+DROP VIEW IF EXISTS price_feed_with_nulls;
+
+DROP INDEX IF EXISTS mkt_state_by_last_swap_avg_price_idx;
+DROP INDEX IF EXISTS mkt_state_by_tvl_idx;

--- a/rust/processor/src/db/postgres/migrations/2025-05-21-212304_optimize_stats_queries/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-05-21-212304_optimize_stats_queries/up.sql
@@ -1,0 +1,30 @@
+-- Your SQL goes here
+
+-- Can't create an index on `delta_percentage` since it's a view-only calculated column, otherwise
+-- it'd be good to have an index for it here.
+-- The other un-indexed columns used in market stats queries are below.
+CREATE INDEX IF NOT EXISTS mkt_state_by_last_swap_avg_price_idx 
+ON market_latest_state_event (last_swap_avg_execution_price_q64 DESC);
+
+CREATE INDEX IF NOT EXISTS mkt_state_by_tvl_idx
+ON market_latest_state_event (instantaneous_stats_total_value_locked DESC);
+
+-- Join market_state entries with their corresponding 24h price delta entries, if they exist.
+-- Using `postgrest` filters to achieve the same thing, with `.in` or `or.(eq...eq...eq...)`
+-- is extremely inefficient and slows down the query by a factor of 100-150x.
+-- Thus the below view is necessary to avoid 20+ second query times on a query that should take
+-- less than 200ms.
+-- Note that this view is still ~30-50x less performant than `market_state`. It should only
+-- be used as an optimization for specific queries when necessary.
+-- For markets without any volume in the past 24 hours, the three new `price_feed` columns
+-- are `null`.
+CREATE VIEW price_feed_with_nulls AS
+SELECT
+  ms.*,
+  pf.open_price_q64, -- `null` if no volume in the last 24h.
+  pf.close_price_q64, -- `null` if no volume in the last 24h.
+  pf.delta_percentage -- `null` if no volume in the last 24h.
+FROM
+  market_state ms
+LEFT JOIN price_feed pf
+  ON ms.market_id = pf.market_id;


### PR DESCRIPTION
# Description

Essentially, postgrest would screw up the query planner and cause the query to go from 150ms normally to 20s when queried with in or or(eq…eq…eq…) filters, which normally are fairly performant.

Not sure exactly why, but it's a common issue with postgrest and ORMs in general.

Consolidating the two queries (merged through javascript/typescript logic) into one with a view circumvents the issue entirely.

Most of the SDK types stay exactly the same, but the processor will need a hot upgrade.

- [x] Add indexes to last swap avg price and TVL
- [x] Address the 400/404 response codes we're seeing in Vercel.
- [x] Address the slow price feed queries
- [x] Fixes the `down.sql` for the previous migration, as it didn't need a couple lines.

