### PR TITLE
refactor(ECO-3373): Add the `chunked_candlesticks_metadata` function

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2025-06-26-211533_add_chunked_candlesticks_metadata/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-06-26-211533_add_chunked_candlesticks_metadata/down.sql
@@ -1,0 +1,7 @@
+-- This file should undo anything in `up.sql`
+
+DROP FUNCTION chunked_candlesticks_metadata(
+  market_id NUMERIC,
+  period period_type,
+  chunk_size INTEGER
+);

--- a/rust/processor/src/db/postgres/migrations/2025-06-26-211533_add_chunked_candlesticks_metadata/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-06-26-211533_add_chunked_candlesticks_metadata/up.sql
@@ -1,0 +1,60 @@
+-- Your SQL goes here
+
+CREATE FUNCTION chunked_candlesticks_metadata(
+  market_id NUMERIC,
+  period period_type,
+  chunk_size INTEGER
+)
+RETURNS TABLE (
+  chunk_id INTEGER,
+  first_start_time TIMESTAMP,
+  last_start_time TIMESTAMP,
+  num_items INTEGER
+)
+AS $$
+  /*
+   * Returns metadata for time-chunked candlesticks.
+   *
+   * Each "chunk" groups a consecutive range of `chunk_size` rows from the
+   * `candlesticks` table for a given market and period, ordered by `start_time`.
+   *
+   * Parameters:
+   * - market_id: the market to query
+   * - period: the candlestick interval (e.g. 'period_1h')
+   * - chunk_size: how many rows per chunk
+   *
+   * Output:
+   * - chunk_id: numeric index of the chunk (0-based)
+   * - first_start_time: earliest start_time in the chunk
+   * - last_start_time: latest start_time in the chunk
+   * - num_items: number of rows in this chunk
+   *
+   * This is useful for pagination, summarization, or caching of large candlestick datasets.
+   * 
+   * Note that this chunks data for *all* rows in the table, so it will not scale infinitely
+   * as the number of candlesticks for a market increases. However, increasing the chunk size
+   * can address this to some extent. Plus, there's no reason to reasonably expect a single
+   * market will ever have more than a million rows any time soon. At a chunk size of 2,000
+   * a million rows would only be 500 total chunks, and the current largest number of rows
+   * for a single market/period is ~33,000.
+   */
+  WITH chunked_data AS (
+    SELECT 
+      start_time,
+      -- The entire purpose of this function is to return stable (cacheable) metadata for a
+      -- market's candlesticks, so to ensure consistent results, `start_time` must be in ASC
+      -- order. Otherwise, new candlesticks would change the first/last start times for
+      -- historical chunks, even if the chunk size is constant.
+      (ROW_NUMBER() OVER (ORDER BY start_time ASC) - 1) / chunk_size AS chunk_id
+    FROM candlesticks 
+    WHERE market_id = $1 AND period = $2
+  )
+  SELECT 
+    chunk_id,
+    MIN(start_time) AS first_start_time,
+    MAX(start_time) AS last_start_time,
+    COUNT(*) AS num_items
+  FROM chunked_data
+  GROUP BY chunk_id
+  ORDER BY chunk_id;
+$$ LANGUAGE SQL;


### PR DESCRIPTION
# Add the `chunked_candlesticks_metadata` function

For the normal candlesticks, the new parcel caching mechanism is over-engineered, difficult to use/understand, and inefficient, as it stores data in a way that causes parcels to have overlapping data.

This is because it constructs the metadata about candlestick parcels on the fly, rather than computing all of them at once and then using that information to fetch parcelized/chunked data.

The new implementation will use a postgres window function to pre-compute all of the cached candlestick metadata for each market, starting from the very first candlestick. It then uses this data to know how many different chunks of candlesticks it needs to fetch/retrieve from the database. This is all logic performed within the api endpoint, so that the outward facing/public API for candlesticks will remain almost exactly the same.

Example for globe market:

```sql
WITH chunked_data AS (
    SELECT 
      start_time,
      -- The entire purpose of this function is to return stable (cacheable) metadata for a
      -- market's candlesticks, so to ensure consistent results, `start_time` must be in ASC
      -- order. Otherwise, new candlesticks would change the first/last start times for
      -- historical chunks, even if the chunk size is constant.
      (ROW_NUMBER() OVER (ORDER BY start_time ASC) - 1) / 500 AS chunk_id
    FROM candlesticks 
    WHERE market_id = 2 AND period = 'period_1m'
  )
  SELECT 
    chunk_id,
    MIN(start_time) AS first_start_time,
    MAX(start_time) AS last_start_time,
    COUNT(*) AS num_items
  FROM chunked_data
  GROUP BY chunk_id
  ORDER BY chunk_id;


 chunk_id |  first_start_time   |   last_start_time   | num_items 
----------+---------------------+---------------------+-----------
        0 | 2024-11-20 03:55:00 | 2024-11-20 12:38:00 |       500
        1 | 2024-11-20 12:39:00 | 2024-11-21 03:52:00 |       500
        2 | 2024-11-21 03:54:00 | 2024-11-23 05:38:00 |       500
        3 | 2024-11-23 06:14:00 | 2024-12-04 16:11:00 |       500
        4 | 2024-12-04 16:54:00 | 2024-12-18 14:09:00 |       500
        5 | 2024-12-18 14:10:00 | 2024-12-29 02:47:00 |       500
        6 | 2024-12-29 02:59:00 | 2025-01-18 00:48:00 |       500
        7 | 2025-01-18 01:04:00 | 2025-01-22 10:08:00 |       500
        8 | 2025-01-22 10:09:00 | 2025-01-24 00:56:00 |       500
        9 | 2025-01-24 00:58:00 | 2025-01-26 13:41:00 |       500
       10 | 2025-01-26 13:50:00 | 2025-01-28 17:28:00 |       500
       11 | 2025-01-28 17:33:00 | 2025-01-30 13:34:00 |       500
       12 | 2025-01-30 13:36:00 | 2025-02-01 03:18:00 |       500
       13 | 2025-02-01 03:19:00 | 2025-02-02 17:18:00 |       500
       14 | 2025-02-02 17:19:00 | 2025-02-05 09:56:00 |       500
       15 | 2025-02-05 10:01:00 | 2025-02-06 22:31:00 |       500
       16 | 2025-02-06 22:32:00 | 2025-02-10 05:20:00 |       500
       17 | 2025-02-10 05:35:00 | 2025-02-12 01:58:00 |       500
       18 | 2025-02-12 02:03:00 | 2025-02-13 13:25:00 |       500
       19 | 2025-02-13 13:30:00 | 2025-02-15 18:13:00 |       500
       20 | 2025-02-15 18:16:00 | 2025-02-19 03:58:00 |       500
       21 | 2025-02-19 03:59:00 | 2025-02-19 19:36:00 |       500
       22 | 2025-02-19 19:37:00 | 2025-02-20 23:00:00 |       500
       23 | 2025-02-20 23:01:00 | 2025-02-21 16:27:00 |       500
       24 | 2025-02-21 16:28:00 | 2025-02-23 04:39:00 |       500
       25 | 2025-02-23 04:40:00 | 2025-02-24 18:31:00 |       500
       26 | 2025-02-24 18:35:00 | 2025-02-28 21:53:00 |       500
       27 | 2025-02-28 21:54:00 | 2025-03-05 12:47:00 |       500
       28 | 2025-03-05 12:48:00 | 2025-03-10 10:16:00 |       500
       29 | 2025-03-10 10:17:00 | 2025-03-11 12:30:00 |       500
       30 | 2025-03-11 12:31:00 | 2025-03-17 09:15:00 |       500
       31 | 2025-03-17 09:23:00 | 2025-03-29 18:19:00 |       500
       32 | 2025-03-29 19:12:00 | 2025-04-13 16:55:00 |       500
       33 | 2025-04-13 16:59:00 | 2025-05-07 17:38:00 |       500
       34 | 2025-05-07 21:50:00 | 2025-05-26 11:18:00 |       500
       35 | 2025-05-26 13:05:00 | 2025-06-15 06:25:00 |       500
       36 | 2025-06-15 06:41:00 | 2025-06-26 20:50:00 |       205
```
